### PR TITLE
Add membership expiry processing and goodbye email

### DIFF
--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            Raz Peel, Karine Frenette Gaufre, Francois Bessette, Claude Vessaz
  * Author URI:        https://www.facebook.com/razpeel
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '1.2.1' );
+define( 'ACC_USER_IMPORTER_VERSION', '1.2.2' );
 
 /**
  * Plugin activation.
@@ -51,11 +51,9 @@ function deactivate_acc_user_importer() {
 register_activation_hook( __FILE__, 'activate_acc_user_importer' );
 register_deactivation_hook( __FILE__, 'deactivate_acc_user_importer' );
 
-//FIXME ----this comes from other plugin, anything to cleanup? is this in the right order?--------
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 include_once( ACC_BASE_DIR . '/admin/queues.php' );
 include_once( ACC_BASE_DIR . '/admin/acc-user-manager.php' );
-//---------------------------------------------------------------------
 
 /**
  * Core plugin class.

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -8,9 +8,6 @@ function acc_adapt_acc_adminpage(){
 	add_action('wp_authenticate_user', 'acc_validate_user_login', 10, 2);
 }
 
-add_action( 'user_register', 'acc_send_welcome_email', 10, 1);
-
-
 
 /**
  * On plugin activation, schedule CRON job.
@@ -102,44 +99,12 @@ function acc_send_welcome_email($user_id) {
 	$test = acc_send_email( $user_email, 0 );
 }
 
-/**
- * Check user membership expiry and if past, send goodbye email.
- * FIXME FIXME FIXME!  We used to send an email on role change.
- * And send only 1 email.  Now this code will not change role,
- * and will send email each time expiry is checked!  Need to find a fix.
- *
- * TODO: add a new user meta called account_status and set to value
- * Approved or Rejected.
- */
-function acc_check_if_user_expired($user) {
-    $userID = $user->ID;
-
-    $wp_caps = get_user_meta( $userID, 'wp_capabilities', 'true' );
-    $role = array_keys((array)$wp_caps);
-    if($role[0] == "administrator") {
-    	return;
-    }
-
-    $expiry = get_user_meta( $userID, 'expiry', 'true' );
-	//FIXME why KFG wrote the next line and left it unused??
-    //$expiry_formatted = date("Y-m-d", strtotime($expiry));
-    if (empty($expiry)) {
-    	return;
-    }
-
-	//If user membership expiry is before today, he is expired
-	if ($expiry < date("Y-m-d")) { 
-
-    	// Send goodbye email
-		//FIXME Why did KFG create a new user variable here??
-    	$u = new WP_User( $userID );
-		if(!empty($u->user_email)) {
-			//FIXME Re-enable once we know how to send only 1 email.
-			//$email = acc_send_email( $u->user_email, 1 );
-		}
-    }
-
-    return $user;
+function acc_send_goodbye_email($user_id) {
+	$user = get_userdata($user_id);
+	$user_email = $user->user_email;
+	$test = acc_send_email( $user_email, 1 );
 }
+
+
 
 

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -97,7 +97,7 @@ class acc_user_importer_Admin {
 	public function accUserAPI() {
 	
 		//create response object
-		$api_response = Array();
+		$api_response = [];
 		
 		//kill script if current user lacks permission to edit other users
 		if ( current_user_can( "edit_users" ) == false ) {
@@ -277,7 +277,7 @@ class acc_user_importer_Admin {
 
 
 		//create response object
-		$api_response = Array();
+		$api_response = [];
 		$this->log_dual("Start processing batch of " . count($users) . " users");
 		
 		//fail gracefully is dataset is empty
@@ -559,8 +559,8 @@ class acc_user_importer_Admin {
 		$this->log_dual("Now looking for expired members.");
 
 		//create response object
-		$api_response = Array();
-		$db_users = get_users("all_with_meta");
+		$api_response = [];
+		$db_users = get_users(['fields' => 'all_with_meta']);
 		$num_active = 0;
 		$num_inactive = 0;
 
@@ -632,7 +632,7 @@ class acc_user_importer_Admin {
 		$auth_request = wp_remote_post( $acc_token_uri , $post_args );
 		
 		//create response object for local api
-		$api_response = Array();
+		$api_response = [];
 		
 		//check response and return data using local api
 		if ( is_wp_error( $auth_request ) ) {
@@ -696,7 +696,7 @@ class acc_user_importer_Admin {
 		*/
 		
 		//create response object
-		$api_response = Array();
+		$api_response = [];
 			
 		//if the post request fails
 		if ( is_wp_error( $auth_request ) ) {

--- a/admin/js/acc_user_importer-admin.js
+++ b/admin/js/acc_user_importer-admin.js
@@ -90,7 +90,10 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 			
 					//Enable Buttons At End
 					else {
-						
+
+						//Now that we have updated all members, check for expiry
+						wpProccessExpiry();
+
 						logLocalOutput("&nbsp;");
 						logLocalOutput("<b><u>Membership update complete.</u>");
 						logLocalOutput("--Parsed data for " + usersInData + " people total.");
@@ -249,7 +252,7 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 		logLocalOutput("..");
 		
 		var apiData = {'action': 'accUserAPI','request': 'processMemberData','security': ajax_object.nonce, 'dataset': JSON.stringify(accDataset)};
-		
+
 		jQuery.post(ajax_object.url, apiData, function(response) {
 			var responseObject = JSON.parse(response);
 			
@@ -266,6 +269,28 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 		});
 	}
 	
+	/**
+	 * Ask Wordpress to update database with parsed membership info.
+	 */
+	 function wpProccessExpiry () {
+
+		logLocalOutput("Now asking to process member expiry");
+		logLocalOutput("..");
+
+		var apiData = {'action': 'accUserAPI','request': 'processExpiry','security': ajax_object.nonce, 'dataset': JSON.stringify('')};
+
+		jQuery.post(ajax_object.url, apiData, function(response) {
+			var responseObject = JSON.parse(response);
+
+			if (responseObject.message == "success") {
+				logLocalOutput(responseObject.log);
+				logLocalOutput("Finished expiry processing.");
+			} else {
+				logLocalOutput("Error: " + (responseObject.errorMessage ? responseObject.errorMessage : 'Unknown.'));
+			}
+		});
+	}
+
 	/**
 	 * Unused - Test Mode -> Run the journey, while we are watching.
 	 */

--- a/admin/js/acc_user_importer-admin.js
+++ b/admin/js/acc_user_importer-admin.js
@@ -91,9 +91,6 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 					//Enable Buttons At End
 					else {
 
-						//Now that we have updated all members, check for expiry
-						wpProccessExpiry();
-
 						logLocalOutput("&nbsp;");
 						logLocalOutput("<b><u>Membership update complete.</u>");
 						logLocalOutput("--Parsed data for " + usersInData + " people total.");
@@ -101,14 +98,8 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 						logLocalOutput("--Updated data for " + updatedUsers + " people total.");
 						logLocalOutput("--Errors updating " + usersWithErrors + " accounts total.</b>");
 						
-						$("#update_status_submit, #debug_status_submit").removeAttr("disabled");
-						logLocalOutput("&nbsp;");
-						logLocalOutput("This journey has come to an end.");
-						var accSyncEndTime = new Date();
-						var duration = (accSyncEndTime.getTime() - accSyncStartTime.getTime()) / 1000;
-						logLocalOutput("Start time: " + accSyncStartTime);
-						logLocalOutput("End time: " + accSyncEndTime);
-						logLocalOutput("Duration: " + duration + "seconds");
+						//Now that we have updated all members, check for expiry
+						wpProccessExpiry();
 					}
 			
 				}, onPostRequestFailure);	
@@ -270,14 +261,13 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 	}
 	
 	/**
-	 * Ask Wordpress to update database with parsed membership info.
+	 * Ask Wordpress to scan user database for expired memberships
 	 */
 	 function wpProccessExpiry () {
 
-		logLocalOutput("Now asking to process member expiry");
-		logLocalOutput("..");
+		//logLocalOutput("Requesting to process member expiry");
 
-		var apiData = {'action': 'accUserAPI','request': 'processExpiry','security': ajax_object.nonce, 'dataset': JSON.stringify('')};
+		var apiData = {'action': 'accUserAPI','request': 'processExpiry','security': ajax_object.nonce, 'dataset': ''};
 
 		jQuery.post(ajax_object.url, apiData, function(response) {
 			var responseObject = JSON.parse(response);
@@ -285,6 +275,15 @@ var usersInData, roleRefreshed, newUsers, updatedUsers, usersWithErrors, accSync
 			if (responseObject.message == "success") {
 				logLocalOutput(responseObject.log);
 				logLocalOutput("Finished expiry processing.");
+
+				$("#update_status_submit, #debug_status_submit").removeAttr("disabled");
+				logLocalOutput("&nbsp;");
+				logLocalOutput("This journey has come to an end.");
+				var accSyncEndTime = new Date();
+				var duration = (accSyncEndTime.getTime() - accSyncStartTime.getTime()) / 1000;
+				logLocalOutput("Start time: " + accSyncStartTime);
+				logLocalOutput("End time: " + accSyncEndTime);
+				logLocalOutput("Duration: " + duration + "seconds");
 			} else {
 				logLocalOutput("Error: " + (responseObject.errorMessage ? responseObject.errorMessage : 'Unknown.'));
 			}

--- a/public/class-acc_user_importer-public.php
+++ b/public/class-acc_user_importer-public.php
@@ -44,6 +44,7 @@ class acc_user_importer_Public {
 		$fields[ 'membership' ] = __( 'Membership' );
 		$fields[ 'expiry' ] = __( 'Expiry' );
 		$fields[ 'city' ] = __( 'City' );
+		$fields[ 'acc_status' ] = __( 'ACC Status' );
 		
 		//remove useless fields
 		unset($fields['aim']);

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,30 @@ The plugin provides the following 3 web pages for configuration:
 == User Guide ==
 
 == Road Map ==
+Here are some ideas that could be implemented, sorted by likelyhood.
+-setting: email addresses to notify about new and expired members
+-setting: email addresses to notify about plugin operation
+-setting: disable access for expired members
+-setting: email addresses to never expire (ex: webmaster)
+-Send summary email to an admin email. Sent only when triggered by cron,
+ this way we can aggregate all information into 1 email.
+ What info would admin want to know in summary email?
+	-number of received records
+	-list of new members
+	-list of expired members
+	-errors encountered by plugin (by type)
+	-number of active/inactive members in local db
+-there is already a Wordpress setting (see General) for default role when creating
+ a user. Use this setting and get rid of default_role ACC setting.
+-keep only N most recent log files
+-add a action and filter hook when receiving new users. This way someone could 
+ decide to filter out some people, or reformat phone numbers, etc.
+-give warning about weird cases. Example: a member that is no longer part of 
+ 	the imported list, but still have an expiry date in the future.
+-option to automatically delete inactive members
+-option to provide a grace period (keep member access for N days 
+ after its membership is expired)
+
 
 == Contact ==
 https://github.com/francoisbessette
@@ -43,7 +67,47 @@ https://github.com/cloetzi
 
 == Acknowledgements ==
 
+== Test Cases ==
+After making changes, here are tests to perform to verify proper operation.
+Test on a staging or development site with email transmission disabled.
+-Trigger plugin manually using Update button
+-Verify log in Update window
+-Trigger plugin by Cron job: install WP Control plugin, and under that plugin,
+ check Cron Events and for the job acc_automatic_import, click 'Run Now'.
+-Verify log file is created correctly. Download it and inspect it.
+-In the log file, the following errors are normal. They are caused by
+ family members having the same email address, or not having an email address.
+    > error: no valid email given, cannot create new user account.
+    > error, email already used by someone else, skip
+-verify that a goodbye email is sent (if option is enabled) to an expired user
+-Test user creation
+    -delete an existing user in the local database
+    -trigger the plugin to import membership
+    -verify user is re-created
+    -verify all fields associated to newly created user. 
+    -verify user_login (username) is set according to the configured setting.
+    -verify user has the right default role.
+    -verify that a welcome email is sent (if option is enabled).
+-Test user expiry
+    -pick an inactive user in the local DB.
+    -in the user profile page, double-check that the expiry date is in
+     the past. Force the acc_status to active and save changes.
+    -run the plugin import
+    -the plugin should notice that the expiry date is in the past
+     and change acc_status to inactive.
+    -verify goodbye email is sent (if option is enabled).
+
+
 == Changelog ==
+1.2.2 Francois Bessette
+    -add a new processing loop to review membership expiry date and send
+     welcome and goodbye emails. This is done after the import phase.
+    -add one more user meta variable called acc_status, with value
+     either active or inactive. This is needed to detect transition
+     and only send 1 email.
+    -clean a few logs
+    -translate email settings to english. French can come later.
+
 1.2.1 Francois Bessette
     -Fix bug when default role was set to organisateur-trice.
 

--- a/template/email_settings.php
+++ b/template/email_settings.php
@@ -66,9 +66,9 @@
 				<tbody>
 
 					<tr>
-						<th>Activé?</th>
-						<th>Nom du courriel</th>
-						<th>Contenu</th>					
+						<th>Active?</th>
+						<th>Email type</th>
+						<th>Content</th>					
 						<th></th>					
 						<th></th>					
 						<th></th>					
@@ -84,10 +84,10 @@
 							</div>
 						</th>
 						<th colspan="1" scope="row">
-							Courriel de bienvenue
+							Welcome email
 						</th>
 						<td colspan="6">
-							Sujet: <input name="welcome_email_title" id="welcome_email_title" type="text" style="width:100%;max-width:400px;" value="<?php echo $welcome_title ?>"> <br> <br>
+							Subject: <input name="welcome_email_title" id="welcome_email_title" type="text" style="width:100%;max-width:400px;" value="<?php echo $welcome_title ?>"> <br> <br>
 							<?php wp_editor($welcome_email, "welcome_email"); ?>
 						</td>
 					</tr>
@@ -99,10 +99,10 @@
 							</div>
 						</th>
 						<th colspan="1" scope="row">
-							Courriel pour membres Ex-membres<br> (après 1 mois d'expiration)
+							Goodbye email
 						</th>
 						<td colspan="6">
-							Sujet: <input name="expired_email_title" id="expired_email_title" type="text" style="width:100%;max-width:400px;" value="<?php echo $expired_title ?>"> <br> <br>
+							Subject: <input name="expired_email_title" id="expired_email_title" type="text" style="width:100%;max-width:400px;" value="<?php echo $expired_title ?>"> <br> <br>
 							<?php wp_editor($expired_email, "expired_email"); ?>
 						</td>
 					</tr>


### PR DESCRIPTION
1.2.2 Francois Bessette
    -add a new processing loop to review membership expiry date and send
     welcome and goodbye emails. This is done after the import phase.
    -add one more user meta variable called acc_status, with value
     either active or inactive. This is needed to detect transition
     and only send 1 email.
    -clean a few logs
    -translate email settings to english. French can come later.