### PR TITLE
Add capability to notify an admin about membership changes

### DIFF
--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           1.2.4
+ * Version:           1.2.6
  * Author:            Raz Peel, Karine Frenette Gaufre, Francois Bessette, Claude Vessaz
  * Author URI:        https://www.facebook.com/razpeel
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '1.2.4' );
+define( 'ACC_USER_IMPORTER_VERSION', '1.2.6' );
 
 /**
  * Plugin activation.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           1.2.3
+ * Version:           1.2.4
  * Author:            Raz Peel, Karine Frenette Gaufre, Francois Bessette, Claude Vessaz
  * Author URI:        https://www.facebook.com/razpeel
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '1.2.3' );
+define( 'ACC_USER_IMPORTER_VERSION', '1.2.4' );
 
 /**
  * Plugin activation.

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -616,7 +616,7 @@ class acc_user_importer_Admin {
 			(!empty($new_users) || !empty($expired_users))) {
 			$email_addrs = $options['accUM_notification_emails'];
 
-			$title = "ACC membership change notification";
+			$title = accUM_get_default_notif_title();
 			if (isset($options['accUM_notification_title'])) {
 				$title = $options['accUM_notification_title'];
 			}
@@ -629,7 +629,7 @@ class acc_user_importer_Admin {
 			foreach ( $expired_users as $user ) {
 				$content .= $user . "\n";
 			}
-			$this->log_dual("email to: $email_addrs");
+			$this->log_dual("Sending notification email to: $email_addrs");
 			$this->log_dual("email title=$title");
 			$this->log_dual("email content=$content");
 			$rc = wp_mail($email_addrs, $title, $content, 'Content-Type: text/plain; charset=UTF-8' );

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -47,7 +47,8 @@
 	function accUM_get_login_name_mapping_default() {return 'Firstname Lastname';}
 	function accUM_get_update_user_login_default() {return 'No';}
 	function accUM_get_default_role_default() {return 'Subscriber';}
-
+	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
+	
 	/*
 	 * Register user settings for options page.
 	 */
@@ -160,6 +161,19 @@
 				'type' => 'text',
 				'name' => 'accUM_notification_emails',
 			)
+		);
+
+		add_settings_field(
+			'accUM_notification_title',	//ID
+			'Title of notification email',
+			'accUM_text_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'type' => 'text',
+				'name' => 'accUM_notification_title',
+				'default' => accUM_get_default_notif_title(),
+				)
 		);
 
 		//Register the array that will store all plugin data

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -150,6 +150,18 @@
 			)
 		);
 
+		add_settings_field(
+			'accUM_notification_emails',	//ID
+			'Who to notify about membership creation/expiry? List of emails, comma separated. Leave blank for no notifications',
+			'accUM_text_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'type' => 'text',
+				'name' => 'accUM_notification_emails',
+			)
+		);
+
 		//Register the array that will store all plugin data
 		register_setting( 'acc_admin_page', 'accUM_data', 'accUM_sanitize_data' );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ACC User Importer ===
 Contributors: Raz Peel, Karine Frenette-G, Francois Bessette, Claude Vessaz
 Tags: 
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Repository: https://github.com/acc-wp/acc_user_importer
@@ -29,9 +29,8 @@ The plugin provides the following 2 web pages for configuration:
 
 
 == Installation ==
-1. Make sure the ACC User Importer plugin is installed and activated.
-1. install "acc_user_importer.zip".
-1. Activate the plugin.
+1. install "acc_user_importer_x_y_z.zip".
+2. Activate the plugin.
 
 == User Guide ==
 
@@ -141,6 +140,11 @@ Test on a staging or development site with email transmission disabled.
 
 
 == Changelog ==
+1.2.4 Francois Bessette
+    -The user can now configure a list of emails who will be notified whenever
+     the web site membership changes (user created/renewed, or becames expired).
+    -Leave the field blank if you want no email notifications.
+
 1.2.3 Francois Bessette
     -Fix minor review comments
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ACC User Importer ===
 Contributors: Raz Peel, Karine Frenette-G, Francois Bessette, Claude Vessaz
 Tags: 
-Stable tag: 1.2.4
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Repository: https://github.com/acc-wp/acc_user_importer
@@ -140,6 +140,13 @@ Test on a staging or development site with email transmission disabled.
 
 
 == Changelog ==
+1.2.6 Francois Bessette
+    -Add an option to specify the title for the notification email.
+
+1.2.5 Francois Besssette
+    -Ignore error if data received from ACC server is missing Membership
+     field. Temp fix for Mtl, never pushed to Github.
+
 1.2.4 Francois Bessette
     -The user can now configure a list of emails who will be notified whenever
      the web site membership changes (user created/renewed, or becames expired).


### PR DESCRIPTION
Adding code for an idea I had: notify (by email) an admin account whenever there are membership changes.  There is no checking to see if the list of entered email is valid.

Tested, works.