### PR TITLE
Change user role on expiry, restore on renewal

### DIFF
--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           1.2.6
+ * Version:           1.3.0
  * Author:            Raz Peel, Karine Frenette Gaufre, Francois Bessette, Claude Vessaz
  * Author URI:        https://www.facebook.com/razpeel
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '1.2.6' );
+define( 'ACC_USER_IMPORTER_VERSION', '1.3.0' );
 
 /**
  * Plugin activation.

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -616,9 +616,11 @@ class acc_user_importer_Admin {
 					$this->log_dual("Initial update of user $user->ID $user->display_name to inactive");
 				}
 
-				// If needed, change the user role to the expired role
+				// If needed, change the user role to the expired role.
+				// Do not change roles of administrators to prevent lockout.
 				$user_roles = $user->roles;
 				if ($do_expire_role == 'on' &&
+					!in_array('administrator', $user_roles, true) &&
 					!in_array($expired_role, $user_roles, true)) {
 					$this->log_dual("Changing user $user->ID $user->display_name role to $expired_role");
 					$expired_role_users[] = "$user->display_name  ($user->user_email)";

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -556,7 +556,33 @@ class acc_user_importer_Admin {
 		// Get user-configurable option values
 		$options = get_option('accUM_data');
 
+		// Get the default_role setting
+		if (!isset($options['accUM_default_role'])) {
+			$this->log_dual("accUM_default_role is empty");
+			$default_role = accUM_get_default_role_default();
+		} else {
+			$default_role = $options['accUM_default_role'];
+		}
+
+		// Get the accUM_do_expire_role setting
+		if (!isset($options['accUM_do_expire_role'])) {
+			$do_expire_role = accUM_get_do_expire_role_default();
+		} else {
+			$do_expire_role = $options['accUM_do_expire_role'];
+		}
+
+		// Get the accUM_expired_role setting
+		if (!isset($options['accUM_expired_role'])) {
+			$this->log_dual("accUM_expired_role is empty");
+			$expired_role = accUM_get_expired_role_default();
+		} else {
+			$expired_role = $options['accUM_expired_role'];
+		}
+
 		$this->log_dual("Now looking for expired members.");
+		if ($do_expire_role == 'on') {
+			$this->log_dual("and will update their roles to $expired_role");
+		}
 
 		//create response object
 		$api_response = [];
@@ -565,10 +591,13 @@ class acc_user_importer_Admin {
 		$num_inactive = 0;
 		$new_users = [];
 		$expired_users = [];
+		$expired_role_users = [];
+		$restored_role_users = [];
 
 		foreach ( $db_users as $key => $user ) {
 
 			if ($this->is_user_expired($user)) {
+				// User is expired
 				$num_inactive++;
 				if (isset($user->acc_status)) {
 					if ($user->acc_status == 'active') {
@@ -587,7 +616,20 @@ class acc_user_importer_Admin {
 					$this->log_dual("Initial update of user $user->ID $user->display_name to inactive");
 				}
 
+				// If needed, change the user role to the expired role
+				$user_roles = $user->roles;
+				if ($do_expire_role == 'on' &&
+					!in_array($expired_role, $user_roles, true)) {
+					$this->log_dual("Changing user $user->ID $user->display_name role to $expired_role");
+					$expired_role_users[] = "$user->display_name  ($user->user_email)";
+					// Save previous user roles (a user may have many roles)
+					update_user_meta($user->ID, 'previous_roles', $user_roles);
+					// Set role to expired role
+					$user->set_role($expired_role);
+				}
+
 			} else {
+				// User has a valid membership
 				$num_active++;
 				if (isset($user->acc_status)) {
 					if ($user->acc_status == 'inactive') {
@@ -604,6 +646,33 @@ class acc_user_importer_Admin {
 					// new plugin executes. Set the field but do not send email.
 					update_user_meta($user->ID, 'acc_status', 'active');
 					$this->log_dual("Initial update of user $user->ID $user->display_name to active");
+				}
+
+				// If needed, restore the previously saved member role. If we dont have a saved
+				// previous role, pick the default role for a new member.
+				if ($do_expire_role == 'on' &&
+					in_array($expired_role, $user->roles, true)) {
+					$restored_role_users[] = "$user->display_name  ($user->user_email)";
+
+					if (empty($user->previous_roles)) {
+						$previous_roles = [$default_role];
+						$this->log_dual("Restoring user $user->ID $user->display_name role from $expired_role to default");
+					} else {
+						$previous_roles = $user->previous_roles;
+						$this->log_dual("Restoring user $user->ID $user->display_name role from $expired_role to previous");
+					}
+
+					$first_role = true;
+					foreach ($previous_roles as $role) {
+						if ($first_role) {
+							$user->set_role($role);
+							$first_role = false;
+							$this->log_dual("Restored role $role");
+						} else {
+							$user->add_role($role);
+							$this->log_dual("Restored role $role");
+						}
+					}
 				}
 			}
 		}
@@ -629,6 +698,14 @@ class acc_user_importer_Admin {
 			foreach ( $expired_users as $user ) {
 				$content .= $user . "\n";
 			}
+			$content .= "\n---members which had their roles changed to expired role---\n";
+			foreach ( $expired_role_users as $user ) {
+				$content .= $user . "\n";
+			}
+			$content .= "\n---members which had their roles restored because they renewed---\n";
+			foreach ( $restored_role_users as $user ) {
+				$content .= $user . "\n";
+			}
 			$this->log_dual("Sending notification email to: $email_addrs");
 			$this->log_dual("email title=$title");
 			$this->log_dual("email content=$content");
@@ -639,8 +716,6 @@ class acc_user_importer_Admin {
 				$this->log_dual("Failed to send notification email");
 			}
 		}
-
-
 
 		$api_response['message'] = "success";
 		$api_response['log'] = $GLOBALS['acc_logstr'];	//Return the big log string

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ACC User Importer ===
 Contributors: Raz Peel, Karine Frenette-G, Francois Bessette, Claude Vessaz
 Tags: 
-Stable tag: 1.2.6
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Repository: https://github.com/acc-wp/acc_user_importer
@@ -140,6 +140,10 @@ Test on a staging or development site with email transmission disabled.
 
 
 == Changelog ==
+1.3.0 Francois Bessette
+    -Add options to change role when member becomes expired, and 
+     restore previous role when member renews.
+
 1.2.6 Francois Bessette
     -Add an option to specify the title for the notification email.
 


### PR DESCRIPTION
Added 2 new settings
-should plugin change the role?
-what role should have the expired members?

In the process_expiry loop (going over all members):
if user is inactive, verify its role and if needed, change it to the expired role. Save the previous role.
if user is active, if needed restore its role from expired to the previous role member had.

Tests done:
-tested member going to expired
-tested member renew (with no previous_role)
-FB7test with role 'translator' expiring ->
	user 600 Francois BessetteTest transitioned to inactive, send goodbye email if enabled
	Expired 600 Francois BessetteTest has roles: translator
	Changing user 600 Francois BessetteTest role to ex-membre

-alexStHilaire renew and had previous_role organisateur
	user 566 Alexandre St-Hilaire transitioned to active, send welcome email if enabled
	Active 566 Alexandre St-Hilaire has roles: ex-membre
	Restoring user 566 Alexandre St-Hilaire role from ex-membre to previous organisateur_trice
	Restored role organisateur_trice

-FB7test with role ex-membre and previous=translator renews
	user 600 Francois BessetteTest transitioned to active, send welcome email if enabled
	Active 600 Francois BessetteTest has roles: ex-membre
	Restoring user 600 Francois BessetteTest role from ex-membre to previous translator
	Restored role translator

-AndrewK renews and has no previous_role and default set to Author
	user 504 Andrew Kadykalo transitioned to active, send welcome email if enabled
	Active 504 Andrew Kadykalo has roles: ex-membre
	Restoring user 504 Andrew Kadykalo role from ex-membre to default
	Restored role author

-FB7 role translator/auteur/editeur goes expired
	user 600 Francois BessetteTest transitioned to inactive, send goodbye email if enabled
	Expired 600 Francois BessetteTest has roles: translator author editor
	Changing user 600 Francois BessetteTest role to ex-membre
		600	previous_roles	a:3:{i:0;s:10:"translator";i:1;s:6:"author";i:2;s:6:"editor";}

-FB7 role ex-membre renews
	user 600 Francois BessetteTest transitioned to active, send welcome email if enabled
	Active 600 Francois BessetteTest has roles: ex-membre
	Restoring user 600 Francois BessetteTest role from ex-membre to previous
	Restored role translator
	Restored role author
	Restored role editor
		and verified on the User backend, FB7test has all 3 roles restored.
