### PR TITLE
Add Vancouver Student Outdoor Club memberships

### DIFF
--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -63,6 +63,7 @@ class acc_user_importer_Admin {
 		'1830' => ['section' => 'VANCOUVER', 'type' => 'family1'],
 		'1828' => ['section' => 'VANCOUVER', 'type' => 'family2'],
 		'1826' => ['section' => 'VANCOUVER', 'type' => 'child'],
+		'2326' => ['section' => 'VANCOUVER', 'type' => 'student_club'],
 		'1784' => ['section' => 'VANCOUVER ISLAND', 'type' => 'adult'],
 		'1783' => ['section' => 'VANCOUVER ISLAND', 'type' => 'youth'],
 		'1787' => ['section' => 'VANCOUVER ISLAND', 'type' => 'family1'],
@@ -587,7 +588,9 @@ class acc_user_importer_Admin {
 		'family2' => 4,
 		'adult' => 3,
 		'child' => 2,
-		'youth' => 1);
+		'youth' => 1,
+		'student_club' => 0,
+	);
 
 	/**
 	 * Returns true if the type2 membership is preferred over the type1.


### PR DESCRIPTION
The Vancouver section has special student outdoor club associate memberships.  Add ID for this kind of membership to the membership type list.  This membership type is considered the lowest priority for determining membership type stored in Wordpress.