### PR TITLE
Expire members during data rx, members with status PROC should not login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.0 Francois Bessette
+- Save membership status in user database. The primary condition for a
+  valid user is now based on his membership status rather than the expiry date.
+- Do not allow user to login if his membership is in PROC state.
+  Give appropriate login error message.
+- Display membership status in user profile page.
+- During local DB check, give warnings for users with PROC membership status.
+
 ## 2.1.4 Francois Bessette
 - Add option to doublecheck for expired users in local DB.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.4 Francois Bessette
+- Add option to doublecheck for expired users in local DB.
+
 ## 2.1.3 Francois Bessette
 - Merged 2.0.7 change from Keith
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.1 Francois Bessette
+## 2.1.2 Francois Bessette
 
 - Remove "Usernames will transition from ContactID" configuration and associated
   code. This was just for the 2023-05 IT transition, no longer needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.0 Francois Bessette
+## 2.1.1 Francois Bessette
 
 - Remove "Usernames will transition from ContactID" configuration and associated
   code. This was just for the 2023-05 IT transition, no longer needed.
@@ -15,6 +15,7 @@
 - During activation phase, if the previous plugin was not 2.1.0, examine
   the user DB and clean-up the previous_roles variable.
 - Add setting to limit the number of log files
+- Fix PHP error when no email address entered in the Admin to notify option box.
 
 ## 2.0.6 Francois Bessette
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enhance code for sending email to admin, for logging
 - During activation phase, if the previous plugin was not 2.1.0, examine
   the user DB and clean-up the previous_roles variable.
+- Add setting to limit the number of log files
 
 ## 2.0.6 Francois Bessette
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.1.0 Francois Bessette
+
+- Remove "Usernames will transition from ContactID" configuration and associated
+  code. This was just for the 2023-05 IT transition, no longer needed.
+- Add configuration and code to better decide what to do to role when there is
+  a new or expired user. Choices: na, add_role, set_role, remove_role.
+- Remove code which to restore a user previous role when he renews. Too confusing.
+- Print received membership status to log
+- Remove Process_Expiry code which used to be run at the end of membership import.
+  There is no more need to do so since 2mev now signals reliably when members
+  become expired.
+- Enhance code for sending email to admin, for logging
+- During activation phase, if the previous plugin was not 2.1.0, examine
+  the user DB and clean-up the previous_roles variable.
+
 ## 2.0.6 Francois Bessette
 
 - Fix minor problem where member expiry is not performed when plugin is manually

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ such as 2020-11-23T15:05:00. Note that when after an automatic
 the run was manually triggered.
 - Set usernames to: what username to assign new members. Most section
 have decided to standardize on ACC Member Number.
+- Usernames will transition from ContactID? Only to be used by the
+Vancouver section, where members currently have ContactID as their usernames.
+Selecting this option adds a safety check in case the incoming ACC
+member number matches the ContactID of an unrelated member.
+The option is meant to be used only for the transition to the 2M system.
+Leaving the option enabled has the drawback that if a user changes
+his name and email at the same time, the plugin would no
+longer be able to find it and update it in the database.
 - Test mode (do not actually update the local Wordpress database).
 If you enable this option, the plugin will run and will display the
 received data, but will not update the local Wordpress database.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,6 @@ such as 2020-11-23T15:05:00. Note that when after an automatic
 the run was manually triggered.
 - Set usernames to: what username to assign new members. Most section
 have decided to standardize on ACC Member Number.
-- Usernames will transition from ContactID? Only to be used by the
-Vancouver section, where members currently have ContactID as their usernames.
-Selecting this option adds a safety check in case the incoming ACC
-member number matches the ContactID of an unrelated member.
-The option is meant to be used only for the transition to the 2M system.
-Leaving the option enabled has the drawback that if a user changes
-his name and email at the same time, the plugin would no
-longer be able to find it and update it in the database.
 - Test mode (do not actually update the local Wordpress database).
 If you enable this option, the plugin will run and will display the
 received data, but will not update the local Wordpress database.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ have decided to standardize on ACC Member Number.
 - Test mode (do not actually update the local Wordpress database).
 If you enable this option, the plugin will run and will display the
 received data, but will not update the local Wordpress database.
+- Also doublecheck for expired users in local DB? If this option is
+checked, then after syncing the received data from the 2M API,
+an additional step is done: the local database is scanned,
+looking for expired users. This is a safeguard in case 2M forgets
+to notify us of an expired user.
 - When creating a new user, how to change role?
 You have the choice to take no action, set role to a value or add a
 role to the member.
@@ -128,7 +133,7 @@ prematurely, the section will not know about it (no email, no
 role change, but there will be a warning in the plugin log). 
 The user will be able to access the local web site
 until the original expiry date is reached.
-- When the update is triggered manually, there is an additional
+- If the option is set, there is an additional
 step to ensure sanity of the database. It scans
 the whole database of Wordpress users. If a user was "inactive"
 and his expiry date is in the future, a Welcome email is sent

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.1.3
+ * Version:           2.1.4
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.1.3' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.1.4' );
 
 
 /**

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.0.6
+ * Version:           2.1.0
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -27,7 +27,7 @@ define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.0.6' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.1.0' );
 
 /**
  * Plugin activation.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.1.4
+ * Version:           2.2.0
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.1.4' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.2.0' );
 
 
 /**

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.1.1
+ * Version:           2.1.2
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.1.1' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.1.2' );
 
 
 /**

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -24,6 +24,7 @@ if ( ! defined( 'WPINC' ) ) {
 define('ACC_BASE_DIR', WP_PLUGIN_DIR . '/' . dirname(plugin_basename(__FILE__)));
 define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
 define('ACC_MAIN_PLUGIN_FILE_URL', __FILE__);
+define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 
 /**
  * Current plugin version.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.1.0
+ * Version:           2.1.1
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.1.0' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.1.1' );
 
 
 /**

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -23,20 +23,13 @@ if ( ! defined( 'WPINC' ) ) {
 
 define('ACC_BASE_DIR', WP_PLUGIN_DIR . '/' . dirname(plugin_basename(__FILE__)));
 define('ACC_PLUGIN_DIR', plugins_url() . "/acc_user_importer/");
+define('ACC_MAIN_PLUGIN_FILE_URL', __FILE__);
 
 /**
  * Current plugin version.
  */
 define( 'ACC_USER_IMPORTER_VERSION', '2.1.0' );
 
-/**
- * Plugin activation.
- */
-function activate_acc_user_importer() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-acc_user_importer-activator.php';
-	acc_user_importer_Activator::activate();
-	acc_cron_activate();
-}
 
 /**
  * Plugin deactivation.
@@ -47,7 +40,6 @@ function deactivate_acc_user_importer() {
 	acc_user_importer_Deactivator::deactivate();
 }
 
-register_activation_hook( __FILE__, 'activate_acc_user_importer' );
 register_deactivation_hook( __FILE__, 'deactivate_acc_user_importer' );
 
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' );

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -176,3 +176,12 @@ function acc_log( $v ) {
 	}
 }
 
+// Returns the current date plus the specified number of days.
+// The format will be a string like "2026-04-28".
+function acc_now_plus_N_days ($days) {
+		$date = new DateTime(); 					// Get the current date
+		$period = "P" . $days . "D";
+		$date->add(new DateInterval($period));    	//Add N days
+		$return_string = $date->format('Y-m-d');
+		return($return_string);
+	}

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -90,5 +90,53 @@ function acc_send_goodbye_email($user_id) {
 }
 
 
+static $acc_logfile = "";
+
+/*
+ * Generate a new log filename, based on the current day and time. Ex:
+ * plugins/acc_user_importer/logs/log_upgrade_2024-02-13-16-35-04.txt
+ * This is stored in a global variable for convenience so that
+ * each log statement does not have to specifically refer to that file.
+ * On top of that, we store it to the plugin DB because the static var
+ * is periodically re-init to NULL by Wordpress (in-between http requests,
+ * I think).
+ */
+function acc_pick_new_log_file($prefix) {
+	global $acc_logfile;
+	$log_directory = ACC_BASE_DIR . '/logs/';
+	$log_date = date_i18n("Y-m-d-H-i-s");
+	$acc_logfile = $log_directory . $prefix . $log_date . ".txt";
+	//error_log("acc_logfile defined as $acc_logfile");
+	acc_write_log_filename_to_db($acc_logfile);
+	return $acc_logfile;
+}
+
+// Write the current log filename as a plugin DB option.
+function acc_write_log_filename_to_db ($filename) {
+	$options = get_option('accUM_data');
+	$options['log_filename'] = $filename;
+	update_option( 'accUM_data',  $options);
+	//error_log("wrote filename to DB");
+}
+
+// Get the log filename stored in the DB.
+function acc_read_log_filename_from_db () {
+	$options = get_option('accUM_data');
+	$filename = $options['log_filename'];
+	//error_log("read $filename from DB");
+	return $filename;
+}
+
+function acc_log( $v ) {
+	global $acc_logfile;
+	if (empty($acc_logfile)) {
+		$acc_logfile = acc_read_log_filename_from_db();
+	}
+	if (!empty($acc_logfile)) {
+		$log = fopen($acc_logfile, "a");
+		fwrite( $log, $v . "\n");
+		fclose( $log );
+	}
+}
 
 

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -645,10 +645,6 @@ class acc_user_importer_Admin {
 		}
 		$this->log_dual("Using $loginNameMapping as login name.");
 
-		// Get the transitionFromContactID setting
-		$transitionFromContactID = accUM_get_transitionFromContactID();
-		$this->log_dual("Usernames " . ($transitionFromContactID ? "":"DO NOT") . "transition from ContactID");
-
 		// Get the readonly_mode setting
 		$readonly_mode = accUM_get_readonly_mode();
 		if ($readonly_mode) {
@@ -778,31 +774,6 @@ class acc_user_importer_Admin {
 
 			// Check if ID or email already exist. Both should be unique
 			$existingUser = get_user_by('login', $loginName);
-
-			// TEMPORARY CODE TO HELP VANCOUVER SECTION TRANSITION TO 2M PLATFORM
-			// Vancouver needs to transition usernames from ContactID to 2M member_number.
-			// The 'Set username to' setting will be set to member_number. During import,
-			// the plugin will try to get users by loginName set to member_number
-			// but the username in the DB will initially set to ContactID.
-			// Since those 2 number spaces are not distinct, it might happen that
-			// a user member_number is the same as someone else ContactID. And so,
-			// the first time the plugin operates on the DB, it could match the wrong
-			// user.  Add an extra step and make sure that the user name is the right one
-			// to ensure we found the right user.  This setting can be left checked
-			// for a few days after transition with no harm, except that a user
-			// would not be able to change his name and email (at least not at the same time).
-			// So once the plugin has done the full import of the membership and all usernames
-			// have transitioned to member_number, the accUM_transition_from_contactID
-			// setting should be unchecked.  And eventually this piece of code
-			// (7 lines)should be removed.
-			if( is_a( $existingUser, WP_User::class ) && $transitionFromContactID) {
-				// Check if we have a match with either display name or email. If one matches, we assume the user is the same, but the member number changed.
-				if (!($accUserData['display_name'] == $existingUser->display_name || $accUserData['user_email'] == $existingUser->user_email)) {
-					$this->log_dual(" > error (transition from ContactID): looks like " .
-					    "we have a duplicate member number ({$existingUser->display_name}, skipping ");
-					continue;
-				}
-			}
 
 			if( !is_a( $existingUser, WP_User::class ) ) {
 				$this->log_dual(" > not found by login");

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -1324,4 +1324,4 @@ class acc_user_importer_Admin {
 		$GLOBALS['acc_logstr'] .= $string . "<br/>";
 	}
 
-
+}

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -680,6 +680,10 @@ class acc_user_importer_Admin {
 		}
 		$this->log_dual("Using $loginNameMapping as login name.");
 
+		// Get the transitionFromContactID setting
+		$transitionFromContactID = accUM_get_transitionFromContactID();
+		$this->log_dual("Usernames " . ($transitionFromContactID ? "":"DO NOT") . "transition from ContactID");
+
 		// Get the readonly_mode setting
 		$readonly_mode = accUM_get_readonly_mode();
 		if ($readonly_mode) {
@@ -836,6 +840,31 @@ class acc_user_importer_Admin {
 
 			// Check if ID or email already exist. Both should be unique
 			$existingUser = get_user_by('login', $loginName);
+
+			// TEMPORARY CODE TO HELP VANCOUVER SECTION TRANSITION TO 2M PLATFORM
+			// Vancouver needs to transition usernames from ContactID to 2M member_number.
+			// The 'Set username to' setting will be set to member_number. During import,
+			// the plugin will try to get users by loginName set to member_number
+			// but the username in the DB will initially set to ContactID.
+			// Since those 2 number spaces are not distinct, it might happen that
+			// a user member_number is the same as someone else ContactID. And so,
+			// the first time the plugin operates on the DB, it could match the wrong
+			// user.  Add an extra step and make sure that the user name is the right one
+			// to ensure we found the right user.  This setting can be left checked
+			// for a few days after transition with no harm, except that a user
+			// would not be able to change his name and email (at least not at the same time).
+			// So once the plugin has done the full import of the membership and all usernames
+			// have transitioned to member_number, the accUM_transition_from_contactID
+			// setting should be unchecked.  And eventually this piece of code
+			// (7 lines)should be removed.
+			if( is_a( $existingUser, WP_User::class ) && $transitionFromContactID) {
+				// Check if we have a match with either display name or email. If one matches, we assume the user is the same, but the member number changed.
+				if (!($accUserData['display_name'] == $existingUser->display_name || $accUserData['user_email'] == $existingUser->user_email)) {
+					$this->log_dual(" > error (transition from ContactID): looks like " .
+					    "we have a duplicate member number ({$existingUser->display_name}, skipping ");
+					continue;
+				}
+			}
 
 			if( !is_a( $existingUser, WP_User::class ) ) {
 				$this->log_dual(" > not found by login");

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -52,7 +52,8 @@
 	function accUM_get_ex_user_role_action_default() {return 'set_role';}	
 	function accUM_readonly_mode_default() {return 'off';}
 	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
-
+	function accUM_get_default_max_log_files() {return 500;}
+	
 	// Get the section name as per the settings
 	function accUM_getSectionName ( ) {
 		$options = get_option('accUM_data');
@@ -232,6 +233,19 @@
 				'type' => 'text',
 				'name' => 'accUM_notification_title',
 				'default' => accUM_get_default_notif_title(),
+				)
+		);
+
+		add_settings_field(
+			'accUM_max_log_files',			//ID
+			'Maximum number of log files to keep',
+			'accUM_text_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'type' => 'number',
+				'name' => 'accUM_max_log_files',
+				'default' => accUM_get_default_max_log_files(),
 				)
 		);
 

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -51,6 +51,7 @@
 	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
 	function accUM_get_ex_user_role_action_default() {return 'set_role';}	
 	function accUM_readonly_mode_default() {return 'off';}
+	function accUM_verify_expiry_default() {return 'off';}
 	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_max_log_files() {return 500;}
 	function accUM_get_notification_emails_default() {return '';}
@@ -75,6 +76,17 @@
 			$readonly_mode = $options['accUM_readonly_mode'];
 		}
 		return $readonly_mode == 'on';
+	}
+
+	// Returns true if we need to scan the DB looking for expired users
+	function accUM_get_verify_expiry() {
+		$options = get_option('accUM_data');
+		if (!isset($options['accUM_verify_expiry'])) {
+			$setting = accUM_verify_expiry_default();
+		} else {
+			$setting = $options['accUM_verify_expiry'];
+		}
+		return $setting == 'on';
 	}
 
 	/*
@@ -156,6 +168,18 @@
 			array(
 				'name' => 'accUM_readonly_mode',
 				'default' => accUM_readonly_mode_default(),
+			)
+		);
+
+		add_settings_field(
+			'accUM_verify_expiry',			//ID
+			'Also check user expiry in local DB',
+			'accUM_chkbox_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'name' => 'accUM_verify_expiry',
+				'default' => accUM_verify_expiry_default(),
 			)
 		);
 

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -46,11 +46,12 @@
 	// Define functions to get default values from different files.
 	function accUM_get_login_name_mapping_default() {return 'member_number';}
 	function accUM_get_section_default() {return 'Ottawa';}
-	function accUM_get_default_role_default() {return 'subscriber';}
+	function accUM_get_new_user_role_action_default() {return 'set_role';}
+	function accUM_get_new_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
-	function accUM_get_do_expire_role_default() {return 'off';}
+	function accUM_get_ex_user_role_action_default() {return 'set_role';}	
 	function accUM_readonly_mode_default() {return 'off';}
-	function accUM_get_expired_role_default() {return 'subscriber';}
+	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
 
 	// Get the section name as per the settings
 	function accUM_getSectionName ( ) {
@@ -156,42 +157,56 @@
 			)
 		);
 
+		add_settings_field(
+			'accUM_new_user_role_action',	//ID
+			'When creating a new user, what should I do with role?',
+			'accUM_select_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'name' => 'accUM_new_user_role_action',
+				'values' => ['set_role' => 'Set role', 'add_role' => 'Add role', 'nc' => 'Do not change role'],
+				'default' => accUM_get_new_user_role_action_default(),
+			)
+		);
+
 		$roles = wp_roles()->get_names();
 		add_settings_field(
-			'accUM_default_role',			//ID
-			'When creating a new user, set role to',	//Title
+			'accUM_new_user_role_value',	//ID
+			'role value?',					//Title
 			'accUM_select_render',			//Callback
 			'acc_admin_page',				//Page
 			'accUM_user_section',			//Section
 			array(
-				'name' => 'accUM_default_role',
+				'name' => 'accUM_new_user_role_value',
 				'values' => $roles,
-				'default' => accUM_get_default_role_default(),
+				'default' => accUM_get_new_user_role_value_default(),
 			)
 		);
 
 		add_settings_field(
-			'accUM_do_expire_role',			//ID
-			'Should plugin modify the role when a member becomes expired?',	//Title
-			'accUM_chkbox_render',			//Callback
-			'acc_admin_page',				//Page
-			'accUM_user_section',			//Section
-			array(
-				'name' => 'accUM_do_expire_role',
-				'default' => accUM_get_do_expire_role_default(),
-			)
-		);
-
-		add_settings_field(
-			'accUM_expired_role',			//ID
-			'Set role of expired members to',	//Title
+			'accUM_ex_user_role_action',	//ID
+			'When expiring a user, what should I do with role?',
 			'accUM_select_render',			//Callback
 			'acc_admin_page',				//Page
 			'accUM_user_section',			//Section
 			array(
-				'name' => 'accUM_expired_role',
+				'name' => 'accUM_ex_user_role_action',
+				'values' => ['set_role' => 'Set role', 'remove_role' => 'Remove role', 'nc' => 'Do not change role'],
+				'default' => accUM_get_ex_user_role_action_default(),
+			)
+		);
+
+		add_settings_field(
+			'accUM_ex_user_role_value',		//ID
+			'role value?',					//Title
+			'accUM_select_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'name' => 'accUM_ex_user_role_value',
 				'values' => $roles,
-				'default' => accUM_get_expired_role_default(),
+				'default' => accUM_get_ex_user_role_value_default(),
 			)
 		);
 

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -49,7 +49,6 @@
 	function accUM_get_default_role_default() {return 'subscriber';}
 	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
 	function accUM_get_do_expire_role_default() {return 'off';}
-	function accUM_transition_from_contactID_default() {return 'off';}
 	function accUM_readonly_mode_default() {return 'off';}
 	function accUM_get_expired_role_default() {return 'subscriber';}
 
@@ -63,18 +62,7 @@
 		}
 		return $sectionName;
 	}
-
-	// Returns true if the database is transitioning from FromContactID usernames.
-	function accUM_get_transitionFromContactID() {
-		$options = get_option('accUM_data');
-		if (!isset($options['accUM_transition_from_contactID'])) {
-			$transitionFromContactID = accUM_transition_from_contactID_default();
-		} else {
-			$transitionFromContactID = $options['accUM_transition_from_contactID'];
-		}
-		return $transitionFromContactID == 'on';
-	}
-
+	
 	// Returns true if the plugin operates in read-only mode (for debug)
 	function accUM_get_readonly_mode() {
 		$options = get_option('accUM_data');
@@ -152,19 +140,6 @@
 				'name' => 'accUM_login_name_mapping',
 				'values' => ['member_number' => 'ACC member number', 'Firstname Lastname' => 'Firstname Lastname'],
 				'default' => accUM_get_login_name_mapping_default(),
-			)
-		);
-
-		add_settings_field(
-			'accUM_transition_from_contactID',			//ID
-			'Usernames will transition from ContactID to Interpodia member_number? ' .
-			'Check this box for a safer transition (verifies that member being synced has the right name)',
-			'accUM_chkbox_render',			//Callback
-			'acc_admin_page',				//Page
-			'accUM_user_section',			//Section
-			array(
-				'name' => 'accUM_transition_from_contactID',
-				'default' => accUM_transition_from_contactID_default(),
 			)
 		);
 

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -50,6 +50,7 @@
 	function accUM_get_new_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
 	function accUM_get_ex_user_role_action_default() {return 'set_role';}	
+	function accUM_transition_from_contactID_default() {return 'off';}
 	function accUM_readonly_mode_default() {return 'off';}
 	function accUM_verify_expiry_default() {return 'off';}
 	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
@@ -66,7 +67,18 @@
 		}
 		return $sectionName;
 	}
-	
+
+	// Returns true if the database is transitioning from FromContactID usernames.
+	function accUM_get_transitionFromContactID() {
+		$options = get_option('accUM_data');
+		if (!isset($options['accUM_transition_from_contactID'])) {
+			$transitionFromContactID = accUM_transition_from_contactID_default();
+		} else {
+			$transitionFromContactID = $options['accUM_transition_from_contactID'];
+		}
+		return $transitionFromContactID == 'on';
+	}
+
 	// Returns true if the plugin operates in read-only mode (for debug)
 	function accUM_get_readonly_mode() {
 		$options = get_option('accUM_data');
@@ -155,6 +167,19 @@
 				'name' => 'accUM_login_name_mapping',
 				'values' => ['member_number' => 'ACC member number', 'Firstname Lastname' => 'Firstname Lastname'],
 				'default' => accUM_get_login_name_mapping_default(),
+			)
+		);
+
+		add_settings_field(
+			'accUM_transition_from_contactID',			//ID
+			'Usernames will transition from ContactID to Interpodia member_number? ' .
+			'Check this box for a safer transition (verifies that member being synced has the right name)',
+			'accUM_chkbox_render',			//Callback
+			'acc_admin_page',				//Page
+			'accUM_user_section',			//Section
+			array(
+				'name' => 'accUM_transition_from_contactID',
+				'default' => accUM_transition_from_contactID_default(),
 			)
 		);
 

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -53,6 +53,7 @@
 	function accUM_readonly_mode_default() {return 'off';}
 	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_max_log_files() {return 500;}
+	function accUM_get_notification_emails_default() {return '';}
 	
 	// Get the section name as per the settings
 	function accUM_getSectionName ( ) {
@@ -220,6 +221,7 @@
 			array(
 				'type' => 'text',
 				'name' => 'accUM_notification_emails',
+				'default' => accUM_get_notification_emails_default(),
 			)
 		);
 

--- a/assets/styles/admin.css
+++ b/assets/styles/admin.css
@@ -7,7 +7,7 @@
 
 ul.log_files strong {
   display: inline-block;
-  width: 75px;
+  width: 100px;
 }
 ul.log_files {
   list-style: disc;

--- a/includes/class-acc_user_importer-activator.php
+++ b/includes/class-acc_user_importer-activator.php
@@ -28,8 +28,12 @@ class acc_user_importer_Activator {
 	 */
 	public function activate() {
 		$this->read_previous_plugin_version_from_db();
-		$this->process_upgrade();
-		$this->write_new_plugin_version_to_db();
+
+		if ($this->version != $this->previous_plugin_version) {
+			$this->process_upgrade();
+			$this->write_new_plugin_version_to_db();
+		}
+
 		acc_cron_activate();
 	}
 
@@ -56,6 +60,8 @@ class acc_user_importer_Activator {
 		$options = get_option('accUM_data');
 		$options['accUM_plugin_version'] = $this->version;
 		update_option( 'accUM_data',  $options);
+		//error_log("Updated version# from $this->previous_plugin_version " .
+		//	 	  "to $this->version in DB\n");		//Normally disabled
 	}
 
    /**

--- a/includes/class-acc_user_importer-activator.php
+++ b/includes/class-acc_user_importer-activator.php
@@ -98,9 +98,8 @@ class acc_user_importer_Activator {
 	 * plugins/acc_user_importer/logs/log_upgrade_2024-02-13-16-35-04.txt
 	 */
 	private function pick_new_log_filename($prefix) {
-		$log_directory = ACC_BASE_DIR . '/logs/';
 		$log_date = date_i18n("Y-m-d-H-i-s");
-		$log_filename = $log_directory . $prefix . $log_date . ".txt";
+		$log_filename = ACC_LOG_DIR . $prefix . $log_date . ".txt";
 		return $log_filename;
 	}
 

--- a/includes/class-acc_user_importer-activator.php
+++ b/includes/class-acc_user_importer-activator.php
@@ -11,11 +11,97 @@
 
 class acc_user_importer_Activator {
 
+	private $plugin_name;
+	private $version;
+	private $previous_plugin_version;
+
+
+	public function __construct( $plugin_name, $version ) {
+		$this->plugin_name = $plugin_name;
+		$this->version = $version;
+		register_activation_hook( ACC_MAIN_PLUGIN_FILE_URL, array( $this, 'activate'));
+	}
+
+
 	/**
 	 * Activation scripts.
 	 */
-	public static function activate() {
+	public function activate() {
+		$this->read_previous_plugin_version_from_db();
+		$this->process_upgrade();
+		$this->write_new_plugin_version_to_db();
+		acc_cron_activate();
+	}
 
+
+	// Check version number of plugin which ran last.
+	// Starting in v2.1.0, we store the version of the plugin in the database, 
+	// and this info is available when we activate to see if any upgrade
+	// or downgrade work is needed.
+	private function read_previous_plugin_version_from_db() {
+		$options = get_option('accUM_data');
+		if (!empty($options['accUM_plugin_version'])) {
+		   $this->previous_plugin_version = $options['accUM_plugin_version'];
+		} else {
+		   $this->previous_plugin_version = 'unknown';
+		}
+   }
+
+   public function get_previous_plugin_version() {
+	   return $this->previous_plugin_version;
+   }
+
+	// Write the current plugin version in the DB.
+	private function write_new_plugin_version_to_db () {
+		$options = get_option('accUM_data');
+		$options['accUM_plugin_version'] = $this->version;
+		update_option( 'accUM_data',  $options);
+	}
+
+   /**
+	 * Upon activation, there might be some upgrade/downgrade cleanup work.
+	 */
+	private function process_upgrade() {
+
+		$previous_version = $this->get_previous_plugin_version();
+		if ($previous_version === 'unknown' ||
+		    ($previous_version > '1.3.0' && $previous_version < '2.1.0')) {
+
+			// Some upgrade work has to be done
+			$log_file = $this->pick_new_log_filename("log_upgrade_");
+			error_log("Upgrade from $previous_version to $this->version needed\n", 3, $log_file);
+			$this->scan_user_db_and_remove_previous_roles($log_file);
+			error_log("Upgrade done\n", 3, $log_file);
+		}
+	}
+
+   /**
+	 * Remove user meta "previous_roles" which was used from version 1.3.0 to 2.1.0
+	 * and that we no longer use.  This is not really critical, but it is best
+	 * to not pollute the DB with obsolete elements.
+	 */
+	private function scan_user_db_and_remove_previous_roles ($log_file) {
+
+		$user_ids = get_users(['fields' => 'ID']);
+		foreach ( $user_ids as $user_id ) {
+			$user = get_userdata($user_id);
+			if (isset($user->previous_roles)) {
+				$rc = delete_user_meta($user_id, 'previous_roles');
+				error_log("Removed obsolete 'previous_role' for user {$user_id}, result={$rc}\n",
+						  3, $log_file);
+			}
+		}
+	}
+
+	/*
+     * Generate a new log file, based on the current day and time. Ex:
+	 * plugins/acc_user_importer/logs/log_upgrade_2024-02-13-16-35-04.txt
+	 */
+	private function pick_new_log_filename($prefix) {
+		$log_directory = ACC_BASE_DIR . '/logs/';
+		$log_date = date_i18n("Y-m-d-H-i-s");
+		$log_filename = $log_directory . $prefix . $log_date . ".txt";
+		return $log_filename;
 	}
 
 }

--- a/includes/class-acc_user_importer.php
+++ b/includes/class-acc_user_importer.php
@@ -71,6 +71,10 @@ class acc_user_importer {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-acc_user_importer-public.php';
 
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-acc_user_importer-activator.php';
+
+		new acc_user_importer_Activator($this->get_plugin_name(), $this->get_version());
+
 		$this->loader = new acc_user_importer_Loader();
 
 	}

--- a/public/class-acc_user_importer-public.php
+++ b/public/class-acc_user_importer-public.php
@@ -45,7 +45,8 @@ class acc_user_importer_Public {
 		$fields[ 'membership_type' ] = __( 'Membership Type' );
 		$fields[ 'expiry' ] = __( 'Expiry' );
 		$fields[ 'city' ] = __( 'City' );
-		$fields[ 'acc_status' ] = __( 'ACC Status' );
+		$fields[ 'membership_status' ] = __( 'ACC Membership Status (ex:ISSU,PROC,EXP)' );
+		$fields[ 'acc_status' ] = __( 'Internal status' );
 		
 		//remove useless fields
 		unset($fields['aim']);

--- a/template/acc_logs.php
+++ b/template/acc_logs.php
@@ -1,12 +1,11 @@
 <?php 
-	$log_directory  = ACC_BASE_DIR . '/logs/';
 	$log_folder 	= ACC_PLUGIN_DIR . '/logs/';
 	$log_list = "";
 
 
 	//PHP to delete log files
 	if(!empty($_GET["acc_nonce"]) && check_admin_referer( 'trash-log', 'acc_nonce' ) === 1) {
-		$file_to_delete = $log_directory . $_GET["log"];
+		$file_to_delete = ACC_LOG_DIR . $_GET["log"];
 		if(file_exists($file_to_delete))
 			unlink($file_to_delete);
 	}
@@ -18,7 +17,7 @@
 	<ul class="log_files">
 
 <?php 
-	chdir($log_directory);
+	chdir(ACC_LOG_DIR);
 	array_multisort(array_map('basename', ($files = glob("*.txt"))), SORT_DESC, $files);
 	foreach($files as $filename)
 	{

--- a/template/cron_settings.php
+++ b/template/cron_settings.php
@@ -1,7 +1,6 @@
 
 <div class="wrap">
 	<?php 
-	$log_directory  = ACC_BASE_DIR . '/logs/';
 	$cron_options = get_option("cron");
 	$cron_schedules = wp_get_schedules();
 


### PR DESCRIPTION
These are changes I did mainly to help ACC Montreal who are importing members from 3 different sections.
The main issue was the plugin expiry processing. That processing was going over the whole user database and was expiring anybody with an expired valid_to date, and changing their role. The new role would often be set incorrectly, because the plugin was following the config of whatever context it happened to be running. For instance, if the plugin was configured to import members from Montreal, and the expiry phase found a Outaouais user to be expired, it would change its role to old_member_mtl or similar name (not sure I have the right name).

The solution is to remove the expiry sequence, and expire members when we receive the data from 2mev. This is possible because recently (fall 2023?) 2mev started sending notifications when a member 'expires'.  In other words, now that 2mev tells us when a member expires, we no longer need the plugin to have a safeguard function scanning the whole database of users and watching for expired members.  

It also makes the processing much faster because the plugin only processes a few entries, and does not need to scan the whole database of users each times it runs.  

**WARNING**: The plugin settings have changed a bit, this will also help the MTL section to deal with 3 different sections.  Upgrading to 2.1.2 does not correctly preserve the role-related settings, so after activation, please review the 4 roles settings and set them to the right value. 

Here is a more detailed list of changes.

- Add configuration and code to better decide what to do to role when there is
  a new or expired user. Choices: na, add_role, set_role, remove_role.
- Remove code which to restore a user previous role when he renews. Too confusing.
- Members with status PROC should not be able to login
- Use membership status (instead of valid_to date) as the main criteria to decide if the user is valid or not.
- Print received membership status to log
- Remove Process_Expiry code which used to be run at the end of membership import.
  In theory this is no longer needed however since we do not trust that 2M and local DB
  will always stay in sync,  Add option to check the local database for user expiry.
- Enhance code for sending email to admin, for logging
- During activation phase, if the previous plugin was not 2.1.0, examine
  the user DB and clean-up the previous_roles variable.
- Add setting to limit the number of log files
- Fix PHP error when no email address entered in the Admin to notify option box.