### PR TITLE
sanity check section membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.7 Keith Dunwoody
+
+- Add sanity check for member being a member of the section being imported.  The API has recently
+  been returning Prince George member numbers for the Vancouver section.
+- Add mapping for student memberships for Vancouver section
+
 ## 2.0.6 Francois Bessette
 
 - Fix minor problem where member expiry is not performed when plugin is manually

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,8 +8,8 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.0.6
- * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre
+ * Version:           2.0.7
+ * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       acc_user_importer

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -742,6 +742,13 @@ class acc_user_importer_Admin {
 				continue;
 			}
 
+			//Safety check in case member is not a member of this section
+			if (empty($userMembershipSection))
+			{
+				$this->log_dual("> error, user is not a member of this section; skip");
+				continue;
+			}
+
 			switch($loginNameMapping) {
 				case 'Firstname Lastname':
 					$loginName = "$userFirstName $userLastName";


### PR DESCRIPTION
Check that a member is actually a member of the section being processed.  Have seen a couple cases recently where 2mev API returns a member of Prince George section while processing the Vancouver section.