### PR TITLE
Fixing missing section options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.4 Terence Goldberg
+- Including additional sections.
+
 ## 2.2.2 Francois Bessette
 - Enhance logic to prioritize parent memberships over child memberships,
   while allowing a membership to be shortened.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Contributors: Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette-G
 
 Tags:
 
-Stable tag: 2.0.6
-
 License: GPLv2 or later
 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ change the token string everytime a different section is selected.
 The format is like this:  SECTION1:Token1,SECTION2:Token2,...
 No space before or after the comma.  The plugin only support these
 section names right now, and make sure the spelling and case is exact:
+
 | Valid Section Names   |
 | ----------- |
-| SQUAMISH      |
-| CALGARY      |
-| MONTRÉAL      |
-| OUTAOUAIS      |
-| OTTAWA      |
+| SQUAMISH   |
+| CALGARY   |
+| MONTRÉAL   |
+| OUTAOUAIS   |
+| OTTAWA   |
 | VANCOUVER   |
+| ROCKY MOUNTAIN   |
+| EDMONTON   |
+| TORONTO   |
+| YUKON   |
+| BUGABOOS   |
 
 - Sync changes since when? On the next run, the plugin will request for
 all membership changes since that date. The field normally shows the
@@ -133,12 +139,12 @@ idea that 2 changes for the same person is happening and it could
 potentially process the expired membership last, leaving the
 member as invalid in the local database. The chosen solution is to
 never bring back a membership expiry date. So if a received
-record indicates that the membership expiry date should be 
+record indicates that the membership expiry date should be
 moved backward in time, we just skip this record, assuming
 it does not represent the latest information.  The limitation is:
 if somehow on the national side a user membership is cancelled
 prematurely, the section will not know about it (no email, no
-role change, but there will be a warning in the plugin log). 
+role change, but there will be a warning in the plugin log).
 The user will be able to access the local web site
 until the original expiry date is reached.
 - If the option is set, there is an additional
@@ -171,7 +177,7 @@ Sending of a Welcome email is done whenever a new user account is created, or wh
 Sending of a Goodbye email is done whenever a membership status is not valid.
 To help with expiry detection and avoid sending an email on every run of the plugin,
 in the database each user has a meta variable called `acc_status` which helps
-detecting if there was a status change or not. 
+detecting if there was a status change or not.
 An email is sent whenever the acc_status state changes. When upgrading an existing installation, we don't want to flood all users with Welcome/Goodbye emails.  So when the plugin runs, it will avoid sending emails for existing users that do not have such variable yet in the database. But it will create the acc_status variable, and from the non will send emails on state changes. Assuming the email checkbox is set, of course.
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Contributors: Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette-G
 
 Tags:
 
+Stable tag: 2.2.4
+
 License: GPLv2 or later
 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.2
+ * Version:           2.2.4
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.2.2' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.2.4' );
 
 
 /**

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -49,14 +49,14 @@
 	function accUM_get_new_user_role_action_default() {return 'set_role';}
 	function accUM_get_new_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_notif_title() {return 'ACC membership change notification';}
-	function accUM_get_ex_user_role_action_default() {return 'set_role';}	
+	function accUM_get_ex_user_role_action_default() {return 'set_role';}
 	function accUM_transition_from_contactID_default() {return 'off';}
 	function accUM_readonly_mode_default() {return 'off';}
 	function accUM_verify_expiry_default() {return 'off';}
 	function accUM_get_ex_user_role_value_default() {return 'subscriber';}
 	function accUM_get_default_max_log_files() {return 500;}
 	function accUM_get_notification_emails_default() {return '';}
-	
+
 	// Get the section name as per the settings
 	function accUM_getSectionName ( ) {
 		$options = get_option('accUM_data');
@@ -123,7 +123,12 @@
 							 'OTTAWA' => 'OTTAWA',
 							 'MONTRÉAL' => 'MONTRÉAL',
 							 'OUTAOUAIS' => 'OUTAOUAIS',
-							 'VANCOUVER' => 'VANCOUVER'],
+							 'VANCOUVER' => 'VANCOUVER',
+							 'ROCKY MOUNTAIN' => 'ROCKY MOUNTAIN',
+							 'EDMONTON' => 'EDMONTON',
+							 'TORONTO' => 'TORONTO',
+							 'YUKON' => 'YUKON',
+							 'BUGABOOS' => 'BUGABOOS'],
 				'default' => accUM_get_section_default(),
 			)
 		);


### PR DESCRIPTION
After deploying the updates from my previous PR (#15), I noticed that it was not possible to select the new sections in settings (See below). 

<img width="1094" alt="Screen Shot 2024-09-05 at 12 49 34 PM" src="https://github.com/user-attachments/assets/752d8eb0-9d5a-4a30-8d53-4bea0f309901">

This is a result of the new options having been omitted from the settings options. To address this, I've added the new section names to the settings options. 

**Updates:**
1. Added the section options to the README and fixed the table layout.
2. Added the new section options to the settings options.
3. Updated version number to 2.2.4 where applicable. 