### PR TITLE
Login Validation Fix ACC-398

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.9 Terence Goldberg
+- Fix: Fixing the display of custom membership validation errors during login so that the error is displayed correctly using Ultimate Member forms. 
+
 ## 2.2.4 Terence Goldberg
 - Including additional sections.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette-G
 
 Tags:
 
-Stable tag: 2.2.4
+Stable tag: 2.2.9
 
 License: GPLv2 or later
 

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.5
+ * Version:           2.2.9
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.2.5' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.2.9' );
 
 
 /**

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.4
+ * Version:           2.2.5
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -29,7 +29,7 @@ define('ACC_LOG_DIR', ACC_BASE_DIR . '/logs/');
 /**
  * Current plugin version.
  */
-define( 'ACC_USER_IMPORTER_VERSION', '2.2.4' );
+define( 'ACC_USER_IMPORTER_VERSION', '2.2.5' );
 
 
 /**

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -2,6 +2,13 @@
 
 add_filter( 'wp_authenticate_user', 'acc_validate_user_login' );
 
+add_filter( 'um_custom_authenticate_error_codes', 'acc_um_custom_authenticate_error_codes' );
+
+function acc_um_custom_authenticate_error_codes( $third_party_codes ) {
+      $third_party_codes[] = "membership_validation_error";
+ return $third_party_codes;
+}
+
 
 /**
  * On plugin activation, schedule CRON job.
@@ -54,7 +61,6 @@ function acc_MembershipStatusIsProc ( $membershipStatus ) {
 function acc_validate_user_login($user) {
 
 	if ($user instanceof WP_User) {
-		error_log('acc_validate_user_login with user object');
 	//Never block an admin
 	if (in_array("administrator", $user->roles)) {
 		return $user;
@@ -74,7 +80,7 @@ function acc_validate_user_login($user) {
 		'formulaire d\'acceptation des risques (à signer chaque année)? Vérifiez l\'état de votre abonnement au ' .
 		'<a href="https://2mev.com/#!/login">https://2mev.com/#!/login</a> afin de pouvoir vous connecter ' .
 		'et participer aux activités. Allouez 24h pour que les changements se propagent au site web local.';
-		$error->add( 403, $msg);
+		$error->add( "membership_validation_error", $msg);
 		return $error;
 	}
 
@@ -91,14 +97,11 @@ function acc_validate_user_login($user) {
 		'Il semble que votre abonnement soit échu. Renouvelez votre abonnement au ' .
 		'<a href="https://www.alpineclubofcanada.ca">www.alpineclubofcanada.ca</a>. ' .
 		'et allouez 24 heures pour que le changement se propage au site web local.';
-		$error->add( 403, $msg);
+		$error->add( "membership_validation_error", $msg);
 		return $error;
 	}
-}else{
-	error_log('acc_validate_user_login error: ' . $user->get_error_message());
 }
 	return $user;
-
 }
 
 

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -51,8 +51,10 @@ function acc_MembershipStatusIsProc ( $membershipStatus ) {
  * User is trying to login.
  * Prevent user login if membership is PROC, EXP or expiry date is passed.
  */
-function acc_validate_user_login(WP_User $user) {
+function acc_validate_user_login($user) {
 
+	if ($user instanceof WP_User) {
+		error_log('acc_validate_user_login with user object');
 	//Never block an admin
 	if (in_array("administrator", $user->roles)) {
 		return $user;
@@ -77,7 +79,7 @@ function acc_validate_user_login(WP_User $user) {
 	}
 
 	// Case where membership is not ISSU, or expiry date is passed. In theory, just
-	// checking for not ISSU should be enough. But I have seen weird cases where 2M forgot to 
+	// checking for not ISSU should be enough. But I have seen weird cases where 2M forgot to
 	// notify us of a user expiry, and checking the expiry date here acts as a safeguard.
 	$expiry= get_user_meta( $user->ID, 'expiry', 'true' );
 	if ((!empty($status) && !acc_validMembershipStatus($status)) ||
@@ -92,8 +94,11 @@ function acc_validate_user_login(WP_User $user) {
 		$error->add( 403, $msg);
 		return $error;
 	}
-
+}else{
+	error_log('acc_validate_user_login error: ' . $user->get_error_message());
+}
 	return $user;
+
 }
 
 

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -5,8 +5,8 @@ add_filter( 'wp_authenticate_user', 'acc_validate_user_login' );
 add_filter( 'um_custom_authenticate_error_codes', 'acc_um_custom_authenticate_error_codes' );
 
 function acc_um_custom_authenticate_error_codes( $third_party_codes ) {
-      $third_party_codes[] = "membership_validation_error";
- return $third_party_codes;
+	$third_party_codes[] = "membership_validation_error";
+	return $third_party_codes;
 }
 
 


### PR DESCRIPTION
Addresses Issues:
1.  https://github.com/acc-wp/acc_user_importer/issues/18. 
2. [ACC-398](https://alpineclubofcanada.atlassian.net/browse/ACC-398)

The fix required three steps: 
1. Update `acc_validate_user_login` to accept both a user or an error. This fixed the critical error that I was experiencing due to the hook being called twice. 
3. Add the `acc_um_custom_authenticate_error_codes` hook to register the custom `membership_validation_error` errors with UM. This ensured that the errors are displayed correctly. 
4. Updated version number accordingly. 

Example of the desired output below:
<img width="1431" alt="Screen Shot 2024-09-10 at 1 54 18 PM" src="https://github.com/user-attachments/assets/f80a4aa4-e2ca-47f8-9793-19850ae12bc2">
