### PR TITLE
add latest student club member number

### DIFF
--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -62,6 +62,7 @@ class acc_user_importer_Admin {
 		'1828' => ['section' => 'VANCOUVER', 'type' => 'family2'],
 		'1826' => ['section' => 'VANCOUVER', 'type' => 'child'],
 		'2326' => ['section' => 'VANCOUVER', 'type' => 'student_club'],
+		'2593' => ['section' => 'VANCOUVER', 'type' => 'student_club'],
 		'1784' => ['section' => 'VANCOUVER ISLAND', 'type' => 'adult'],
 		'1783' => ['section' => 'VANCOUVER ISLAND', 'type' => 'youth'],
 		'1787' => ['section' => 'VANCOUVER ISLAND', 'type' => 'family1'],


### PR DESCRIPTION
Interpodia creates a new member group for each year's student outdoor club members.  Add the 2024/2025 group number.