### PR TITLE
add latest student club member number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.11 Keith Dunwoody
+
+- Add 2024/2025 Student Outdoor Club group number
+
 ## 2.2.10 Terence Goldberg
 
 - Update: Adding prettier commit hooks to improve code formatting.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.10
+ * Version:           2.2.11
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -62,6 +62,7 @@ class acc_user_importer_Admin
         "1828" => ["section" => "VANCOUVER", "type" => "family2"],
         "1826" => ["section" => "VANCOUVER", "type" => "child"],
         "2326" => ["section" => "VANCOUVER", "type" => "student_club"],
+        "2593" => ["section" => "VANCOUVER", "type" => "student_club"],
         "1784" => ["section" => "VANCOUVER ISLAND", "type" => "adult"],
         "1783" => ["section" => "VANCOUVER ISLAND", "type" => "youth"],
         "1787" => ["section" => "VANCOUVER ISLAND", "type" => "family1"],


### PR DESCRIPTION
Interpodia creates a new member group for each year's student outdoor club members.  Add the 2024/2025 group number.