### PR TITLE
Add option to sync a specified list of comma-separated memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.12 Francois Bessette
+
+- Add an option to sync a specified list of comma-separated memberships.
+
 ## 2.2.11 Keith Dunwoody
 
 - Add 2024/2025 Student Outdoor Club group number

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Contributors: Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette-G
 
 Tags:
 
-Stable tag: 2.2.10
-
 License: GPLv2 or later
 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -68,6 +66,9 @@ Save Changes after changing parameters!
   such as 2020-11-23T15:05:00. Note that when after an automatic
   (timer triggered) run, the plugin updates that value, but not when
   the run was manually triggered.
+- Sync this comma-separated list of ACC member numbers: if member numbers
+  are entered in this box, the plugin will just sync the data for those
+  members instead of asking 2M for the list of members who have changes.
 - Set usernames to: what username to assign new members. Most section
   have decided to standardize on ACC Member Number.
 - Usernames will transition from ContactID? Only to be used by the

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.11
+ * Version:           2.2.12
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -32,7 +32,7 @@ define("ACC_LOG_DIR", ACC_BASE_DIR . "/logs/");
 /**
  * Current plugin version.
  */
-define("ACC_USER_IMPORTER_VERSION", "2.2.11");
+define("ACC_USER_IMPORTER_VERSION", "2.2.12");
 
 /**
  * Plugin deactivation.

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -229,6 +229,14 @@ class acc_user_importer_Admin
                 : "Unknown.");
     }
 
+    private function returnApiError($errorString)
+    {
+        $api_response["message"] = "error";
+        $api_response["log"] = $GLOBALS["acc_logstr"];
+        $api_response["errorMessage"] = $errorString;
+        return $api_response;
+    }
+
     /**
      * This is the user import loop (when triggered by a timer)
      */
@@ -385,6 +393,33 @@ class acc_user_importer_Admin
         $options = get_option("accUM_data");
         $sectionName = accUM_getSectionName();
         $sectionApiId = $this->getSectionApiID();
+
+        // There is a plugin setting to specify a list of users to sync.
+        // If it contains something, then instead of asking 2M for a list of
+        // members with changes, we take the user-provided list.
+        $syncList = accUM_get_sync_list();
+        if (!empty($syncList)) {
+            $this->log_dual(
+                "Will sync the following list of users indicated in the plugin settings:"
+            );
+            $this->log_dual("$syncList");
+            $changeList = explode(",", $syncList);
+            $count = count($changeList);
+            if ($count == 0 || in_array(0, $changeList)) {
+                // Invalid list
+                return $this->returnApiError(
+                    "The plugin settings has an invalid list of members to sync"
+                );
+            }
+
+            $this->log_dual("total count=" . $count);
+            $this->log_dual("total members=" . json_encode($changeList));
+            $api_response["count"] = $count;
+            $api_response["results"] = $changeList;
+            $api_response["message"] = "success";
+            $api_response["log"] = $GLOBALS["acc_logstr"];
+            return $api_response;
+        }
 
         // Read token from user settings. Avoid printing token it is sensitive data
         $access_token = $this->getSectionToken();

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -95,6 +95,10 @@ function accUM_get_notification_emails_default()
 {
     return "";
 }
+function accUM_get_sync_list_default()
+{
+    return "";
+}
 
 // Get the section name as per the settings
 function accUM_getSectionName()
@@ -142,6 +146,18 @@ function accUM_get_verify_expiry()
         $setting = $options["accUM_verify_expiry"];
     }
     return $setting == "on";
+}
+
+// Returns true if we need to scan the DB looking for expired users
+function accUM_get_sync_list()
+{
+    $options = get_option("accUM_data");
+    if (!isset($options["accUM_sync_list"])) {
+        $setting = accUM_get_sync_list_default();
+    } else {
+        $setting = $options["accUM_sync_list"];
+    }
+    return $setting;
 }
 
 /*
@@ -208,6 +224,26 @@ function accUM_settings_init()
         [
             "type" => "text",
             "name" => "accUM_since_date",
+            "help" =>
+                "The date gets updated when the plugin runs automatically, " .
+                "but not when it runs manually with the Update button",
+        ]
+    );
+
+    add_settings_field(
+        "accUM_sync_list", //ID
+        "Only sync this comma-separated list of ACC member numbers",
+        "accUM_text_render", //Callback
+        "acc_admin_page", //Page
+        "accUM_user_section", //Section
+        [
+            "type" => "text",
+            "name" => "accUM_sync_list",
+            "default" => accUM_get_sync_list_default(),
+            "help" =>
+                "Normally blank. Enter member numbers to manually sync those members " .
+                "using the Update button. Dont forget to clear the box afterward to " .
+                "ensure normal automatic sync.",
         ]
     );
 
@@ -399,6 +435,13 @@ function accUM_text_render($args)
     }
 
     $html .= " value=\"$input_value\"";
+
+    //if there is help text to display when hovering
+    if (!empty($args["help"])) {
+        $help = $args["help"];
+        $html .= " title=\"$help\"";
+    }
+
     $html .= "/>";
 
     echo $html;


### PR DESCRIPTION
This new option is useful to manually sync the data of a specific member.  You enter the member number, save configuration, then hit the Manual Update button.