### PR TITLE
Add option to remove obsolete users from database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.13 Francois Bessette
 
-- Add 2 options to control delete of expired members from the database.
+- Add options to control delete of expired members from the database.
 
 ## 2.2.12 Francois Bessette
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.13 Francois Bessette
+
+- Add 2 options to control delete of expired members from the database.
+
 ## 2.2.12 Francois Bessette
 
 - Add an option to sync a specified list of comma-separated memberships.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ Save Changes after changing parameters!
   You have the choice to take no action, set role to a value or remove a
   role from the member.
 - Role value? Value related to the previous choice.
+- How many days before deleting an expired user from database?
+  In order to protect members personal information, it is good practice to eventually
+  delete the data of people who are no longer with the club.
+  Enter the number of days the data should be kept in the database
+  after a member leaves. 0=delete right away, 1=one day, etc.
+- When deleting a user, who will become the new content owner?
+  Enter the new owner login name. Suggestion: manually
+  create a dummy user (example: 'ex-member') to receive
+  ownership of content for users we need to delete,
+  and enter its login name here. The plugin will reassign
+  posts, pages, articles, events. Leaving this box
+  empty will delete the user content along with the user.
+  and you might end up with missing pages or broken links.
 - Admin to notify: Enter an email or a list of emails (comma separated)
   to be notified whenever the plugin adds or expires members.
   Normally an admin email account. Leave blank for no notifications.
@@ -173,6 +186,20 @@ Recent log files. The log file can be downloaded.
   for his membership but has not signed the waiver yet.
 - ISSU: stands for issued, this is a valid membership.
 - EXP: membership is expired.
+
+### Deletion of outdated members
+
+- If you do not want to delete expired members in the database even
+  if they are expired for several years, enter a big integer number such as
+  9999 in the "How many days before deleting" configuration.
+- If you have manually-entered administrative accounts for webmasters,
+  content creators, etc and want to protect their account from being deleted,
+  just make sure they either do not have an expiry date or have one that
+  is far in the future such as 2099-01-01.
+- If the "who will become the new content owner" box is empty,
+  the content is deleted along with outdated members. If the box contains
+  something but that user cannot be found, the plugin generates an error
+  in the log but does not proceed with the delete.
 
 ### What decides if a user can connect or not to the site?
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ Save Changes after changing parameters!
 - Test mode (do not actually update the local Wordpress database).
   If you enable this option, the plugin will run and will display the
   received data, but will not update the local Wordpress database.
-- Also doublecheck for expired users in local DB? If this option is
-  checked, then after syncing the received data from the 2M API,
-  an additional step is done: the local database is scanned,
-  looking for expired users. This is a safeguard in case 2M forgets
-  to notify us of an expired user.
 - When creating a new user, how to change role?
   You have the choice to take no action, set role to a value or add a
   role to the member.
@@ -95,6 +90,15 @@ Save Changes after changing parameters!
   You have the choice to take no action, set role to a value or remove a
   role from the member.
 - Role value? Value related to the previous choice.
+- Also check user expiry in local DB? If this option is
+  checked, then after syncing the received data from the 2M API,
+  an additional step is done: the local database is scanned,
+  looking for expired users. This is a safeguard in case 2M forgets
+  to notify us of an expired user.
+- Delete expired user accounts after a while? Enable feature
+  where obsolete user accounts are deleted after a while. This
+  logic requires the above "Also check user expiry" option
+  and enable the next 2 options.
 - How many days before deleting an expired user from database?
   In order to protect members personal information, it is good practice to eventually
   delete the data of people who are no longer with the club.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           2.2.12
+ * Version:           2.2.13
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -32,7 +32,7 @@ define("ACC_LOG_DIR", ACC_BASE_DIR . "/logs/");
 /**
  * Current plugin version.
  */
-define("ACC_USER_IMPORTER_VERSION", "2.2.12");
+define("ACC_USER_IMPORTER_VERSION", "2.2.13");
 
 /**
  * Plugin deactivation.

--- a/admin/partials/acc_user_importer-admin-settings.php
+++ b/admin/partials/acc_user_importer-admin-settings.php
@@ -87,6 +87,14 @@ function accUM_get_ex_user_role_value_default()
 {
     return "subscriber";
 }
+function accUM_get_when_2_delete_ex_user_default()
+{
+    return 9999;
+}
+function accUM_get_new_owner_default()
+{
+    return "";
+}
 function accUM_get_default_max_log_files()
 {
     return 500;
@@ -148,7 +156,7 @@ function accUM_get_verify_expiry()
     return $setting == "on";
 }
 
-// Returns true if we need to scan the DB looking for expired users
+// Returns the configured list of users to synchronize
 function accUM_get_sync_list()
 {
     $options = get_option("accUM_data");
@@ -156,6 +164,30 @@ function accUM_get_sync_list()
         $setting = accUM_get_sync_list_default();
     } else {
         $setting = $options["accUM_sync_list"];
+    }
+    return $setting;
+}
+
+// Returns the number of days before deleting an expired user.
+function accUM_get_when_2_delete_ex_user()
+{
+    $options = get_option("accUM_data");
+    if (!isset($options["accUM_when_2_delete_ex_user"])) {
+        $setting = accUM_get_when_2_delete_ex_user_default();
+    } else {
+        $setting = $options["accUM_when_2_delete_ex_user"];
+    }
+    return $setting;
+}
+
+// Returns the new content owner when a user is deletec.
+function accUM_get_new_owner()
+{
+    $options = get_option("accUM_data");
+    if (!isset($options["accUM_new_owner"])) {
+        $setting = accUM_get_new_owner_default();
+    } else {
+        $setting = $options["accUM_new_owner"];
     }
     return $setting;
 }
@@ -291,18 +323,6 @@ function accUM_settings_init()
     );
 
     add_settings_field(
-        "accUM_verify_expiry", //ID
-        "Also check user expiry in local DB",
-        "accUM_chkbox_render", //Callback
-        "acc_admin_page", //Page
-        "accUM_user_section", //Section
-        [
-            "name" => "accUM_verify_expiry",
-            "default" => accUM_verify_expiry_default(),
-        ]
-    );
-
-    add_settings_field(
         "accUM_new_user_role_action", //ID
         "When creating a new user, what should I do with role?",
         "accUM_select_render", //Callback
@@ -360,6 +380,54 @@ function accUM_settings_init()
             "name" => "accUM_ex_user_role_value",
             "values" => $roles,
             "default" => accUM_get_ex_user_role_value_default(),
+        ]
+    );
+
+    add_settings_field(
+        "accUM_verify_expiry", //ID
+        "Also check user expiry in local DB",
+        "accUM_chkbox_render", //Callback
+        "acc_admin_page", //Page
+        "accUM_user_section", //Section
+        [
+            "name" => "accUM_verify_expiry",
+            "default" => accUM_verify_expiry_default(),
+        ]
+    );
+
+    add_settings_field(
+        "accUM_when_2_delete_ex_user", //ID
+        "How many days before deleting an expired user from database?  0 to delete right away.",
+        "accUM_text_render", //Callback
+        "acc_admin_page", //Page
+        "accUM_user_section", //Section
+        [
+            "type" => "number",
+            "name" => "accUM_when_2_delete_ex_user",
+            "default" => accUM_get_when_2_delete_ex_user_default(),
+            "help" =>
+                "Enter the number of days after which to delete the user data.",
+        ]
+    );
+
+    add_settings_field(
+        "accUM_new_owner", //ID
+        "when deleting a user, who will become the new content owner?",
+        "accUM_text_render", //Callback
+        "acc_admin_page", //Page
+        "accUM_user_section", //Section
+        [
+            "type" => "text",
+            "name" => "accUM_new_owner",
+            "default" => accUM_get_new_owner_default(),
+            "help" =>
+                "Enter the new owner login name. Suggestion: manually " .
+                "create a dummy user (example: 'ex-member') to receive " .
+                "ownership of content for users we need to delete, " .
+                "and enter its login name here. The plugin will reassign " .
+                "posts, pages, articles, events. Leaving this box " .
+                "empty will delete the user content along with the user, " .
+                "and you might end up with missing pages or broken links.",
         ]
     );
 


### PR DESCRIPTION
This commit has 2 goals:
  - Protect personal information by removing users which no longer needs to be in the database
  - Keep the database light

It introduces 3 new settings to control the deletion of obsolete users:
![Screenshot 2024-11-10 160953](https://github.com/user-attachments/assets/47ca64b1-19f7-4ffe-bdf7-3b2ceb7f6d6f)



Notes:
- If the feature is enabled, the default is to delete user accounts after 365 days of expiry
- If you have manually-entered administrative accounts for webmasters,
  content creators, etc and want to protect their account from being deleted,
  just make sure they either do not have an expiry date or have one that
  is far in the future such as 2099-01-01.
- If the "who will become the new content owner" box is empty,
  the content is deleted along with outdated members. If the box contains
  something but that user cannot be found, the plugin generates an error
  in the log but does not proceed with the delete.
- Some user data may remain present on the website even after the user has
been deleted from the database. For instance, using the plugin "The Event Calendar"
users may define organizers, and enter their email and phone.  That data is
not linked to website users and is not deleted when a user is removed from the DB.
In some way, it is good because using the event calendar you can still look up
an old event and see who organized it. But still, it is personal information
which remains present after the member is gone.

I am including a log file
[Uploading log_auto_2024-11-07-21-25-14.txt…]()
