### PR TITLE
Sync repo with v4.0.8 and fix acc_sections crashes (v4.0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.10 Terence Goldberg
+
+- Fix in_array() and implode() crashes when acc_sections user meta is a string instead of an array
+
 ## 4.0.8 Francois Bessette
 
 - Fix incoming memberships with missing first or last name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 4.0.8 Francois Bessette
+
+- Fix incoming memberships with missing first or last name.
+
+## 4.0.7 Francois Bessette
+
+- Fix upgrade logic, do not upgrade if old version is unknown
+
+## 4.0.6 Francois Bessette
+
+- Allow incoming memberships with missing first or last name
+
+## 4.0.5 Francois Bessette
+
+- On Remove notification, do not change expiry and membership type in user DB
+- Do not report an error if the notification is missing email (child account)
+- In local_db_check do not raise warning for no membership expiry and
+  no signe waiver.
+- During local_db_check raise warning if member is not expired but not part of a section.
+
+## 4.0.4 Francois Bessette
+
+- Fix error caused by missing membership type on remove notification
+
 ## 4.0.3 Francois Bessette
 
 - Fix FQME unknown section error.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Repository: https://github.com/acc-wp/acc_user_importer
 
-
 ## Description
 
 Wordpress plugin used to synchronize the membership list obtained from the
@@ -68,6 +67,7 @@ Submit Changes after changing parameters!
 - Title of admin notification email
 - Maximum number of log files to keep: how many log files to keep on the disk.
   Note that each new notification from Hubspot creates a distinct logfile.
+  Do not use value 0, it does not work.
 - Text to display on failed login because user is expired: What error
   to display to a user when he is expired.
 - Text to display on failed login because user has not signed the waiver:
@@ -94,7 +94,6 @@ the settings.
 - Send Goodbye email? If enabled, the plugin will send a goodbye email.
 - Goodbye email title
 - Goodbye email content
-
 
 #### Manual DB Check
 
@@ -143,11 +142,14 @@ The plugin adds a hooks to Wordpress. Each time a user tries to login,
 the plugin verifies the following:
 
 #### Normal case
+
 - Allow user if acc_mship_expiry date is good and
   acc_waiver_expiry date is good (indicating waiver has been signed).
 - A specific error message is given in the case where the waiver
   needs to be signed.
+
 #### Special cases
+
 - If the user is a Wordpress admin, we allow login
 - If the user does not have an acc_member_id, we assume it is a manually
   created account (for admin purpose) and we allow login.
@@ -157,7 +159,6 @@ the plugin verifies the following:
   membership does not renew, Hubspot will send us a notification to
   terminate membership. And the acc_waiver_expiry field would anyway
   prevent login eventually if the waiver is not renewed.
-
 
 ### Deletion of outdated members
 
@@ -173,7 +174,6 @@ the plugin verifies the following:
   something but that user cannot be found, the plugin generates an error
   in the log but does not proceed with the delete.
 
-
 ### Sending of "Welcome" and "Goodbye" emails
 
 There are checkboxes to control whether a Welcome and Goodbye email are sent to a new or expired member.
@@ -188,12 +188,10 @@ Sending of a Goodbye email is done whenever a member becomes not valid.
 
 ## Caveats
 
-
 ## Ideas for the future
 
 - add a action and filter hook when receiving new users. This way someone could
   decide to filter out some people, or reformat phone numbers, etc.
-
 
 ## Contact
 
@@ -230,7 +228,7 @@ Test on a staging or development site with email transmission disabled.
 - Test user expiry
   - pick an active user in the local DB.
   - in the user profile page, double-check that the acc_mship_expiry date is in
-    the future. 
+    the future.
   - Using Postman, send a Remove notification with acc_mship_expiry in the past.
   - Check the log, the plugin should declare the user is expired.
   - verify goodbye email is sent (if option is enabled).

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           4.0.3
+ * Version:           4.0.8
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -40,7 +40,7 @@ const ACCUM_SEC = "accUM_sec_"; //The per-section settings
 /**
  * Current plugin version.
  */
-define("ACC_USER_IMPORTER_VERSION", "4.0.3");
+define("ACC_USER_IMPORTER_VERSION", "4.0.8");
 
 /**
  * Plugin deactivation.

--- a/acc-importer.php
+++ b/acc-importer.php
@@ -8,7 +8,7 @@
  * Plugin Name:       ACC User Importer
  * Plugin URI:        https://github.com/acc-wp/acc_user_importer
  * Description:       A plugin for synchronizing users from the <a href="http://alpineclubofcanada.ca">Alpine Club of Canada</a> national office.
- * Version:           4.0.8
+ * Version:           4.0.10
  * Author:            Francois Bessette, Claude Vessaz, Raz Peel, Karine Frenette Gaufre, Keith Dunwoody
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
@@ -40,7 +40,7 @@ const ACCUM_SEC = "accUM_sec_"; //The per-section settings
 /**
  * Current plugin version.
  */
-define("ACC_USER_IMPORTER_VERSION", "4.0.8");
+define("ACC_USER_IMPORTER_VERSION", "4.0.10");
 
 /**
  * Plugin deactivation.

--- a/admin/acc-user-manager.php
+++ b/admin/acc-user-manager.php
@@ -136,8 +136,10 @@ function acc_is_user_expired($user)
  */
 function acc_is_waiver_valid($user)
 {
-    if (!$user->has_prop("acc_waiver_expiry") ||
-        $user->acc_waiver_expiry < date("Y-m-d")) {
+    if (
+        !$user->has_prop("acc_waiver_expiry") ||
+        $user->acc_waiver_expiry < date("Y-m-d")
+    ) {
         return false;
     }
     return true;
@@ -278,6 +280,7 @@ function acc_read_log_filename_from_db()
 
 /*
  * Delete old log files to ensure it does not grow to infinity
+ * The setting with value 0 does not work.
  */
 function acc_enforce_max_log_files()
 {

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -179,9 +179,12 @@ class acc_user_importer_Admin
      */
     private function getSectionsAdded($rxdSections, $user)
     {
+        $userSections = is_array($user->acc_sections)
+            ? $user->acc_sections
+            : [];
         $sectionsAdded = [];
         foreach ($rxdSections as $section) {
-            if (!in_array($section, $user->acc_sections)) {
+            if (!in_array($section, $userSections)) {
                 $sectionsAdded[] = $section;
             }
         }
@@ -196,8 +199,11 @@ class acc_user_importer_Admin
      */
     private function getSectionsDeleted($rxdSections, $user)
     {
+        $userSections = is_array($user->acc_sections)
+            ? $user->acc_sections
+            : [];
         $sectionsDeleted = [];
-        foreach ($user->acc_sections as $section) {
+        foreach ($userSections as $section) {
             if (!in_array($section, $rxdSections)) {
                 $sectionsDeleted[] = $section;
             }
@@ -517,7 +523,10 @@ class acc_user_importer_Admin
                             //we serialize and print the string.
                             // $old = serialize($user->$field);
                             // $new = serialize($value);
-                            $old = implode(",", $user->$field);
+                            $oldVal = is_array($user->$field)
+                                ? $user->$field
+                                : [];
+                            $old = implode(",", $oldVal);
                             $new = implode(",", $value);
                             accLog(" > $field changed from " . "$old to $new");
                         } else {

--- a/admin/class-acc_user_importer-admin.php
+++ b/admin/class-acc_user_importer-admin.php
@@ -239,7 +239,7 @@ class acc_user_importer_Admin
         $userFirstName = $params["first_name"] ?? "";
         $userLastName = $params["last_name"] ?? "";
         $userNameInLog = "_" . $userFirstName . "_" . $userLastName;
-        preg_replace("/[^A-Za-z0-9.\-_]/", "_", $userNameInLog);
+        $userNameInLog = preg_replace("/[^A-Za-z0-9\-_]/", "_", $userNameInLog);
         $logfilename = basename(acc_pick_new_log_file($userNameInLog));
         accLog("Received the following membership notification: ");
         accLog(var_export($params, true));
@@ -257,20 +257,24 @@ class acc_user_importer_Admin
             "user_email",
         ];
         foreach ($needed as $index => $field) {
-            if (!isset($params[$field])) {
-                $msg = "Error, missing $field in notification";
-                return $msg;
+            // The 'empty' test will trigger for numbers 0 but that is fine,
+            // we should never have an acc_member_id being 0.
+            if (empty($params[$field])) {
+                if ($field == "user_email") {
+                    // Children memberships often do not have an email address.
+                    // Not an error, just ignore notification.
+                    accLog("No email, skip this notification");
+                    return true;
+                } else {
+                    $msg = "Error, missing $field in notification";
+                    return $msg;
+                }
             }
         }
 
         if ($params["action"] == "add" || $params["action"] == "update") {
             //Sanity checks for additional mandatory fields
-            $needed = [
-                "first_name",
-                "last_name",
-                "acc_sections",
-                "acc_mship_type",
-            ];
+            $needed = ["acc_sections", "acc_mship_type"];
             foreach ($needed as $index => $field) {
                 if (!isset($params[$field])) {
                     $msg = "Error, missing $field in notification";
@@ -288,7 +292,6 @@ class acc_user_importer_Admin
         $action = $params["action"];
         $notifTimestamp = $params["acc_notif_timestamp"];
         $userMemberId = strval($params["acc_member_id"]);
-        $userFullName = $userFirstName . " " . $userLastName;
         $userEmail = strtolower($params["user_email"] ?? "");
         $userCellPhone = strval($params["cell_phone"]) ?? "";
         $receivedSections = $params["acc_sections"] ?? [];
@@ -298,6 +301,20 @@ class acc_user_importer_Admin
         $contactFname = $params["acc_contact_name"] ?? "";
         $contactLname = $params["acc_contact_email"] ?? "";
         $contactPhone = strval($params["acc_contact_phone"]) ?? "";
+
+        if (empty($userFirstName) && empty($userLastName)) {
+            // This case has been seen and can be a valid ACC account.
+            // For display purpose, use the email address.
+            // Wordpress uses nicename as a unique user identifier in URL
+            // and author archives. So it should be unique and
+            // hopefully never change. Best to use the ACC memberID.
+            accLog(" > Empty name, will use email and memberID");
+            $userDisplayname = strstr($userEmail, "@", true);
+            $userNicename = $userMemberId;
+        } else {
+            $userDisplayname = $userFirstName . " " . $userLastName;
+            $userNicename = $userDisplayname;
+        }
 
         // Sanity check received timestamps and convert some to Y-M-D
         // Keep the notification timestamp in UNIX format because
@@ -321,10 +338,14 @@ class acc_user_importer_Admin
 
         $sectionsOfInterest = accUM_get_enabled_sections();
 
-        //Validate received membership type
-        $validMships = acc_get_mship_names();
-        if (!in_array($mshipType, $validMships)) {
-            return " > Error, $mshipType is an invalid membership name";
+        //Validate received membership type (but not for action=remove)
+        if ($action != "remove") {
+            $validMships = acc_get_mship_names();
+            if (!in_array($mshipType, $validMships)) {
+                $msg = " > warning, $mshipType is an invalid membership type";
+                $warnings[] = $msg;
+                accLog($msg);
+            }
         }
 
         // Sanity check: keep only sections we are interested in. Log
@@ -337,7 +358,9 @@ class acc_user_importer_Admin
             $section = trim($section); // Trim whitespace
 
             if (!in_array($section, $validSections)) {
-                $warnings[] = " > warning, $section is an invalid section";
+                $msg = " > warning, $section is an invalid section";
+                $warnings[] = $msg;
+                accLog($msg);
             }
 
             if (in_array($section, $sectionsOfInterest)) {
@@ -354,14 +377,6 @@ class acc_user_importer_Admin
             }
         }
 
-        //Log the info we received for this user
-        // $userInfoString = "Received [" . $notifTimestamp . "] ";
-        // $userInfoString .= "$action $userMemberId ";
-        // $userInfoString .= $userFirstName . " " . $userLastName;
-        // $userInfoString .= " " . $userEmail;
-        // $userInfoString .= " with waiver " . ($waiverExpiry ? "signed" : "NOT signed");
-        // accLog($userInfoString);
-
         // Does received user have a membership?
         if ($action == "remove" || empty($rxdSections)) {
             $rxdSections = [];
@@ -373,14 +388,14 @@ class acc_user_importer_Admin
         $loginNameMapping = accUM_get_login_name_mapping();
         switch ($loginNameMapping) {
             case "Firstname Lastname":
-                $loginName = "$userFirstName $userLastName";
+                $loginName = $userDisplayname;
                 break;
             case "member_number":
             default:
                 $loginName = sanitize_user($userMemberId);
                 break;
         }
-        accLog("User login name is $loginName");
+        accLog(" > User login name is $loginName");
 
         // Create an array for the core wordpress user information.
         // accUserData lists all fields that will be checked for existing users.
@@ -393,7 +408,7 @@ class acc_user_importer_Admin
         $accUserData = [
             "first_name" => $userFirstName,
             "last_name" => $userLastName,
-            "display_name" => $userFirstName . " " . $userLastName,
+            "display_name" => $userDisplayname,
             "user_email" => $userEmail,
         ];
 
@@ -407,7 +422,7 @@ class acc_user_importer_Admin
             "acc_contact_phone" => $contactPhone,
             "cell_phone" => $userCellPhone,
             "acc_member_id" => $userMemberId,
-            "nickname" => $userFirstName . " " . $userLastName,
+            "nickname" => $userDisplayname,
             "acc_sections" => $rxdSections,
         ];
 
@@ -422,7 +437,7 @@ class acc_user_importer_Admin
                 accLog(" > not found by login");
                 $user = get_user_by("email", $userEmail);
                 if (is_a($user, WP_User::class)) {
-                    if ($user->display_name == $userFullName) {
+                    if ($user->display_name == $userDisplayname) {
                         accLog(
                             " > found by email existing userId $user->ID " .
                                 "named $user->display_name"
@@ -460,16 +475,33 @@ class acc_user_importer_Admin
                     $user
                 );
 
-                // Special case for safety: if the action is remove,
-                // bring back the user expiry to today if needed.
+                // Special case for safety: if the action is remove, Hubspot
+                // does not set the expiry field. But we want to keep the one
+                // already in user DB. Unless it needs to be shortened.
+                // Also do not erase the DB acc_mship_type.
                 if (!$userIsValid) {
                     $today = date("Y-m-d");
-                    if (
-                        empty($accUserMetaData["acc_mship_expiry"]) ||
-                        $accUserMetaData["acc_mship_expiry"] > $today
-                    ) {
+                    if (empty($accUserMetaData["acc_mship_expiry"])) {
+                        $accUserMetaData["acc_mship_expiry"] =
+                            $user->acc_mship_expiry;
+                        accLog(
+                            " > No expiry in notification, use " .
+                                "$user->acc_mship_expiry from DB"
+                        );
+                    }
+
+                    if ($accUserMetaData["acc_mship_expiry"] > $today) {
                         $accUserMetaData["acc_mship_expiry"] = $today;
                         accLog(" > Forced user expiry to today");
+                    }
+
+                    if (empty($accUserMetaData["acc_mship_type"])) {
+                        $accUserMetaData["acc_mship_type"] =
+                            $user->acc_mship_type;
+                        accLog(
+                            " > No membership type in notification, use " .
+                                "$user->acc_mship_type from DB"
+                        );
                     }
                 }
 
@@ -535,12 +567,12 @@ class acc_user_importer_Admin
                     );
                     if ($result === false) {
                         $result_str = " failed";
-                        accLog("Error changing loginName for $userFullName");
+                        accLog("Error changing loginName for $userDisplayname");
                     } else {
                         $result_str = " success";
                     }
                     accLog(
-                        "> user {$userID} username changed from " .
+                        " > user {$userID} username changed from " .
                             "{$user->user_login} to {$loginName}, update database $result_str"
                     );
                     //Erase user cache so that future access gets the right data.
@@ -572,7 +604,7 @@ class acc_user_importer_Admin
             //--------CREATE NEW USER-----
             accLog(" > email not found on any other users");
             $accUserData["user_pass"] = wp_generate_password(20);
-            $accUserData["user_nicename"] = $accUserData["display_name"]; //WP will sanitize
+            $accUserData["user_nicename"] = $userNicename; //WP will sanitize
             $accUserData["user_login"] = $loginName;
 
             // Insert new user
@@ -602,7 +634,7 @@ class acc_user_importer_Admin
 
         $operation =
             "The ACC website received the following changes " .
-            "for $userFullName <$userEmail>:";
+            "for $userDisplayname <$userEmail>:";
         $this->send_admin_email(
             $operation,
             $sectionsAdded,
@@ -646,7 +678,7 @@ class acc_user_importer_Admin
             in_array("administrator", $user_roles, true)
         ) {
             $new_user_role_action = "add_role"; //Change set_role to add_role
-        } else if ($newUser && $new_user_role_action == "add_role") {
+        } elseif ($newUser && $new_user_role_action == "add_role") {
             // User has just been created, and Wordpress assigned an annoying
             // default role we want to get rid of. Change to set_role
             // in order to overwrite the Wordpress default role.
@@ -857,7 +889,6 @@ class acc_user_importer_Admin
         $num_active = 0;
         $num_inactive = 0;
         $num_wo_waiver = 0;
-        $processing_email_list = "";
         $more_than_a_year_from_now = acc_now_plus_N_days(400);
         $user_ids = get_users(["fields" => "ID"]);
 
@@ -895,25 +926,37 @@ class acc_user_importer_Admin
             // Some WP accounts are manually created for admin purposes. Those
             // typically have no ACC member ID. Not much validation done on those.
             if (!$user->has_prop("acc_member_id")) {
-                $warnings[] = "$user->display_name ($user->user_email) has no ACC " .
-                              "member ID, it's probably a manually created admin account";
+                $warnings[] =
+                    "$user->display_name ($user->user_email) has no ACC " .
+                    "member ID, it's probably a manually created admin account";
                 continue;
+            }
+
+            if (!$user->has_prop("acc_sections")) {
+                $warnings[] =
+                    "$user->display_name ($user->user_email) has no " .
+                    "acc_sections entry in DB, weird";
+            } elseif (!acc_is_user_expired($user)) {
+                $sections = $user->acc_sections;
+                if (!is_array($sections) || empty($sections)) {
+                    $warnings[] =
+                        "$user->display_name ($user->user_email) is not " .
+                        "expired but not part of any section";
+                }
             }
 
             //Sanity check: raise a warning if user has no or weird expiry date.
             $expiry = $user->acc_mship_expiry ?? null;
             if ($expiry == null) {
-                $warnings[] = "$user->display_name ($user->user_login, $user->user_email) has no membership expiry!";
+                //Must be an auto-renewal account
             } elseif ($expiry > $more_than_a_year_from_now) {
-                $warnings[] = "$user->display_name ($user->user_login, $user->user_email) has expiry=$expiry!";
+                $warnings[] =
+                    "$user->display_name ($user->user_login, $user->user_email) " .
+                    "has suspicious expiry=$expiry!";
             }
 
             //Give warning for users with a membership but no signed waiver
-            if (!acc_is_user_expired($user) &&
-                !acc_is_waiver_valid($user)) {
-                $warnings[] = "$user->display_name ($user->user_login, $user->user_email) has not signed waiver";
-                $processing_email_list .=
-                    $user->display_name . " &lt" . $user->user_email . "&gt, ";
+            if (!acc_is_user_expired($user) && !acc_is_waiver_valid($user)) {
                 $num_wo_waiver++;
             }
 
@@ -934,9 +977,6 @@ class acc_user_importer_Admin
         foreach ($warnings as $warning) {
             accLog("Warning: $warning");
         }
-        accLog(
-            "<br>List of users email with no waivers = $processing_email_list<br>"
-        );
 
         $operation =
             "The ACC web site local DB check made the following changes:";
@@ -1003,9 +1043,9 @@ class acc_user_importer_Admin
         if (
             !empty($email_addrs) &&
             (!empty($sectionsAdded) ||
-             !empty($sectionsDeleted) ||
-             !empty($errors) ||
-             !empty($deleted_users))
+                !empty($sectionsDeleted) ||
+                !empty($errors) ||
+                !empty($deleted_users))
         ) {
             $title = accUM_get_notification_title();
             $content = $operation . "\n\n";

--- a/includes/class-acc_user_importer-activator.php
+++ b/includes/class-acc_user_importer-activator.php
@@ -27,11 +27,10 @@ class acc_user_importer_Activator
     public function activate()
     {
         $oldVersion = $this->get_old_plugin_version_from_db();
-        if (
-            $oldVersion === "unknown" ||
-            ($oldVersion >= "2.0.9" && $oldVersion < "4.0.0")
-        ) {
+        if ($oldVersion >= "2.0.9" && $oldVersion < "4.0.0") {
             $this->process_upgrade($oldVersion);
+        } else {
+            $this->update_plugin_version();
         }
 
         acc_cron_activate();
@@ -50,6 +49,16 @@ class acc_user_importer_Activator
             $oldVersion = "unknown";
         }
         return $oldVersion;
+    }
+
+    // Update the plugin version.
+    // Avoid calling this function if we are changing ACCUM_DATA
+    // somewhere else, there seems to be cache and race issues.
+    private function update_plugin_version()
+    {
+        $options = get_option(ACCUM_DATA);
+        $options["accUM_plugin_version"] = $this->version;
+        update_option(ACCUM_DATA, $options);
     }
 
     /**
@@ -129,11 +138,19 @@ class acc_user_importer_Activator
                 delete_option($candidateOptionName);
                 $rc = update_option($newOptionName, $sectionOption);
                 if ($rc) {
-                    error_log("Renamed setting $candidateOptionName to " .
-                              "$newOptionName\n", 3, $log);
+                    error_log(
+                        "Renamed setting $candidateOptionName to " .
+                            "$newOptionName\n",
+                        3,
+                        $log
+                    );
                 } else {
-                    error_log("Failed to renamed setting $candidateOptionName ".
-                              "to $newOptionName\n", 3, $log);
+                    error_log(
+                        "Failed to renamed setting $candidateOptionName " .
+                            "to $newOptionName\n",
+                        3,
+                        $log
+                    );
                 }
             }
         }
@@ -444,34 +461,62 @@ class acc_user_importer_Activator
 
             if (empty($user->acc_memberships)) {
                 // User is still stored in v2.x format. Let's do our best.
-                error_log(" Warning, user has no acc_memberships array. ".
-                          "We dont know which section he belongs to\n",3,$log);
+                error_log(
+                    " Warning, user has no acc_memberships array. " .
+                        "We dont know which section he belongs to\n",
+                    3,
+                    $log
+                );
 
                 //Convert membership type.
                 //FIXME, is the 2M spelling the same as Hubspot??
                 if (empty($user->membership_type)) {
-                    error_log(" Warning, user has no membership_type\n", 3, $log);
+                    error_log(
+                        " Warning, user has no membership_type\n",
+                        3,
+                        $log
+                    );
                 } else {
-                    $newMshipType = $this->convertMembershipName($user->membership_type);
+                    $newMshipType = $this->convertMembershipName(
+                        $user->membership_type
+                    );
                     update_user_meta($user_id, "acc_mship_type", $newMshipType);
                     error_log(" acc_mship_type=$newMshipType\n", 3, $log);
                 }
-                
+
                 //Convert expiry.
                 if (empty($user->expiry)) {
                     error_log(" Warning, user has no expiry\n", 3, $log);
                 } else {
-                    update_user_meta($user_id, "acc_mship_expiry", $user->expiry);
+                    update_user_meta(
+                        $user_id,
+                        "acc_mship_expiry",
+                        $user->expiry
+                    );
                     error_log(" acc_mship_expiry=$user->expiry\n", 3, $log);
 
                     //Convert membership_status
-                    if ($user->expiry > date("Y-m-d") &&
-                        $user->membership_status == "ISSU") {
-                        update_user_meta($user_id, "acc_waiver_expiry", $user->expiry);
-                        error_log(" user status ISSU, forcing acc_waiver_expiry ".
-                                  "to user expiry\n", 3, $log);
+                    if (
+                        $user->expiry > date("Y-m-d") &&
+                        $user->membership_status == "ISSU"
+                    ) {
+                        update_user_meta(
+                            $user_id,
+                            "acc_waiver_expiry",
+                            $user->expiry
+                        );
+                        error_log(
+                            " user status ISSU, forcing acc_waiver_expiry " .
+                                "to user expiry\n",
+                            3,
+                            $log
+                        );
                     } else {
-                        error_log(" No need to set acc_waiver_expiry\n", 3, $log);
+                        error_log(
+                            " No need to set acc_waiver_expiry\n",
+                            3,
+                            $log
+                        );
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- **Syncs the repository with v4.0.8** changes that were distributed outside of version control (v4.0.4 through v4.0.8)
- **Fixes fatal TypeErrors** caused by legacy `acc_sections` user meta stored as a string instead of an array:
  - `in_array()` crash in `getSectionsAdded()` and `getSectionsDeleted()`
  - `implode()` crash when logging field changes for array-type meta
- Bumps version to **4.0.10** (both plugin header and `ACC_USER_IMPORTER_VERSION` constant)

### v4.0.4-v4.0.8 changes included
- Fix error caused by missing membership type on remove notification
- Preserve expiry and membership type on remove notifications
- Handle child accounts with missing email
- Local DB check improvements for expiry and waiver warnings
- Fix upgrade logic in activator
- Allow incoming memberships with missing first or last name

### v4.0.10 fix
- Added `is_array()` guards in `getSectionsAdded()`, `getSectionsDeleted()`, and the meta field change logger to handle legacy `acc_sections` stored as a string

## Test plan
- [x] Trigger a membership notification for a user whose `acc_sections` meta is stored as a string in the DB
- [x] Verify no fatal error occurs and sections are correctly computed
- [ ] Verify normal operation is unchanged for users with properly stored array values
- [ ] Test remove notification handling (v4.0.4-4.0.5 changes)
- [ ] Test membership with missing first/last name (v4.0.6-4.0.8 changes)